### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,31 @@
 FROM openjdk:8-jdk-slim
 LABEL maintainer="fescobar.systems@gmail.com"
 
-ARG ALLURE_VERSION=allure-2.7.0
+ARG RELEASE=2.7.0
+ARG ALLURE_GITHUB=https://github.com/allure-framework/allure2/releases/download
 
 RUN apt-get update
-RUN apt-get install tar
+RUN apt-get install curl -y
 RUN apt-get install vim -y
 RUN apt install python-pip -y
 RUN pip install Flask
-RUN apt-get install curl -y
 RUN apt-get install --reinstall procps -y
+RUN apt-get install wget
 
 RUN rm /etc/java-8-openjdk/accessibility.properties
 RUN touch /etc/java-8-openjdk/accessibility.properties
 
-COPY $ALLURE_VERSION.tgz /
-RUN tar -xvf $ALLURE_VERSION.tgz
-RUN chmod -R +x /$ALLURE_VERSION/bin
+RUN wget --no-verbose -O /tmp/allure-$RELEASE.zip $ALLURE_GITHUB/$RELEASE/allure-$RELEASE.zip \
+  && unzip /tmp/allure-$RELEASE.zip -d / \
+  && rm -rf /tmp/*
+
+RUN apt-get remove --auto-remove wget -y
+
+RUN chmod -R +x /allure-$RELEASE/bin
 
 COPY allure-docker-api /app/allure-docker-api
 
-ENV ALLURE_HOME=/$ALLURE_VERSION
+ENV ALLURE_HOME=/allure-$RELEASE
 ENV PATH=$PATH:$ALLURE_HOME/bin
 ENV RESULTS_DIRECTORY=/app/allure-results
 ENV REPORT_DIRECTORY=/app/allure-report


### PR DESCRIPTION
- Allure versioning from ARGs instead of hardcoded download URL
- Allure binaries will now be downloaded and unzipped during Docker build instead of physically copying from local. This minimises repo space. 
- Deleted Allure binaries from repo root