### PR TITLE
Render and export emailable report of past reports

### DIFF
--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -1120,7 +1120,7 @@ def clean_results_endpoint():
 @app.route("/emailable-report/render", strict_slashes=False)
 @app.route("/allure-docker-service/emailable-report/render", strict_slashes=False)
 @jwt_required
-def emailable_report_render_endpoint():
+def emailable_report_render_endpoint(): #pylint: disable=too-many-locals
     try:
         project_id = resolve_project(request.args.get('project_id'))
         report_param = resolve_project(request.args.get('report', 'latest'))

--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -1154,10 +1154,15 @@ def emailable_report_render_endpoint():
 
         if report_param == "latest":
             server_url = url_for('latest_report_endpoint', project_id=project_id, _external=True)
+            emailable_report_path = '{}/reports/{}'.format(project_path,
+                                                           EMAILABLE_REPORT_FILE_NAME)
         else:
             project_report_path = '{}/{}'.format(report_param, REPORT_INDEX_FILE)
             server_url = url_for('get_reports_endpoint', project_id=project_id,
                                  path=project_report_path, _external=True)
+            emailable_report_path = '{}/reports/{}_{}'.format(project_path,
+                                                              report_param,
+                                                              EMAILABLE_REPORT_FILE_NAME)
 
         if "SERVER_URL" in os.environ:
             server_url = os.environ['SERVER_URL']
@@ -1165,14 +1170,6 @@ def emailable_report_render_endpoint():
         report = render_template(DEFAULT_TEMPLATE, css=EMAILABLE_REPORT_CSS,
                                  title=EMAILABLE_REPORT_TITLE, projectId=project_id,
                                  serverUrl=server_url, testCases=test_cases)
-
-        if report_param == 'latest':
-            emailable_report_path = '{}/reports/{}'.format(project_path,
-                                                           EMAILABLE_REPORT_FILE_NAME)
-        else:
-            emailable_report_path = '{}/reports/{}_{}'.format(project_path,
-                                                              report_param,
-                                                              EMAILABLE_REPORT_FILE_NAME)
 
         file = None
         try:
@@ -1214,13 +1211,13 @@ def emailable_report_export_endpoint():
 
         project_path = get_project_path(project_id)
 
-        if report_param == 'latest':
-            emailable_report_path = '{}/reports/{}'.format(project_path,
-                                                           EMAILABLE_REPORT_FILE_NAME)
-        else:
-            emailable_report_path = '{}/reports/{}_{}'.format(project_path,
-                                                              report_param,
-                                                              EMAILABLE_REPORT_FILE_NAME)
+        prefix_report_nro = ''
+        if report_param != 'latest':
+            prefix_report_nro = '{}_'.format(report_param)
+        
+        emailable_report_path = '{}/reports/{}{}'.format(project_path,
+                                                         prefix_report_nro,
+                                                         EMAILABLE_REPORT_FILE_NAME)
 
         report = send_file(emailable_report_path, as_attachment=True)
     except Exception as ex:

--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -1137,7 +1137,8 @@ def emailable_report_render_endpoint():
         check_process(GENERATE_REPORT_PROCESS, project_id)
 
         project_path = get_project_path(project_id)
-        tcs_report_project = "{}/reports/{}/data/test-cases/*.json".format(project_path, report_param)
+        tcs_report_project = "{}/reports/{}/data/test-cases/*.json".format(project_path,
+                                                                           report_param)
 
         files = glob.glob(tcs_report_project)
         files.sort(key=os.path.getmtime, reverse=True)
@@ -1165,7 +1166,14 @@ def emailable_report_render_endpoint():
                                  title=EMAILABLE_REPORT_TITLE, projectId=project_id,
                                  serverUrl=server_url, testCases=test_cases)
 
-        emailable_report_path = '{}/reports/{}_{}'.format(project_path, report_param, EMAILABLE_REPORT_FILE_NAME)
+        if report_param == 'latest':
+            emailable_report_path = '{}/reports/{}'.format(project_path,
+                                                           EMAILABLE_REPORT_FILE_NAME)
+        else:
+            emailable_report_path = '{}/reports/{}_{}'.format(project_path,
+                                                              report_param,
+                                                              EMAILABLE_REPORT_FILE_NAME)
+
         file = None
         try:
             file = open(emailable_report_path, "w")
@@ -1205,7 +1213,14 @@ def emailable_report_export_endpoint():
         check_process(GENERATE_REPORT_PROCESS, project_id)
 
         project_path = get_project_path(project_id)
-        emailable_report_path = '{}/reports/{}_{}'.format(project_path, report_param, EMAILABLE_REPORT_FILE_NAME)
+
+        if report_param == 'latest':
+            emailable_report_path = '{}/reports/{}'.format(project_path,
+                                                           EMAILABLE_REPORT_FILE_NAME)
+        else:
+            emailable_report_path = '{}/reports/{}_{}'.format(project_path,
+                                                              report_param,
+                                                              EMAILABLE_REPORT_FILE_NAME)
 
         report = send_file(emailable_report_path, as_attachment=True)
     except Exception as ex:

--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -1214,7 +1214,7 @@ def emailable_report_export_endpoint():
         prefix_report_nro = ''
         if report_param != 'latest':
             prefix_report_nro = '{}_'.format(report_param)
-        
+
         emailable_report_path = '{}/reports/{}{}'.format(project_path,
                                                          prefix_report_nro,
                                                          EMAILABLE_REPORT_FILE_NAME)

--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -348,12 +348,8 @@ if "REFRESH_TOKEN_EXPIRES_IN_DAYS" in os.environ:
 def get_file_as_string(path_file):
     file = None
     content = None
-    try:
-        file = open(path_file, "r")
+    with open(path_file, "r") as file:
         content = file.read()
-    finally:
-        if file is not None:
-            file.close()
     return content
 
 def get_security_specs():
@@ -1171,13 +1167,8 @@ def emailable_report_render_endpoint(): #pylint: disable=too-many-locals
                                  title=EMAILABLE_REPORT_TITLE, projectId=project_id,
                                  serverUrl=server_url, testCases=test_cases)
 
-        file = None
-        try:
-            file = open(emailable_report_path, "w")
+        with open(emailable_report_path, "w") as file:
             file.write(report)
-        finally:
-            if file is not None:
-                file.close()
     except Exception as ex:
         body = {
             'meta_data': {
@@ -1564,20 +1555,15 @@ def send_json_results(results_project, validated_results, processed_files, faile
     for result in validated_results:
         file_name = secure_filename(result.get('file_name'))
         content_base64 = result.get('content_base64')
-        file = None
         try:
-            file = open("%s/%s" % (results_project, file_name), "wb")
-            file.write(content_base64)
+            with open("%s/%s" % (results_project, file_name), "wb") as file:
+                file.write(content_base64)
+            processed_files.append(file_name)
         except Exception as ex:
             error = {}
             error['message'] = str(ex)
             error['file_name'] = file_name
             failed_files.append(error)
-        else:
-            processed_files.append(file_name)
-        finally:
-            if file is not None:
-                file.close()
 
 def create_project(json_body):
     if 'id' not in json_body:

--- a/allure-docker-api/static/swagger/swagger.json
+++ b/allure-docker-api/static/swagger/swagger.json
@@ -362,6 +362,14 @@
                   "schema":{
                      "type":"string"
                   }
+               },
+               {
+                  "in":"query",
+                  "name":"report",
+                  "schema":{
+                     "type":"string",
+                     "default": "latest"
+                  }
                }
             ],
             "responses":{
@@ -398,6 +406,14 @@
                   "name":"project_id",
                   "schema":{
                      "type":"string"
+                  }
+               },
+               {
+                  "in":"query",
+                  "name":"report",
+                  "schema":{
+                     "type":"string",
+                     "default": "latest"
                   }
                }
             ],

--- a/docker-custom/Dockerfile.bionic-custom
+++ b/docker-custom/Dockerfile.bionic-custom
@@ -4,7 +4,7 @@ ARG BUILD_DATE
 ARG BUILD_VERSION=2.13.8-custom
 ARG BUILD_REF=na
 ARG ALLURE_RELEASE=2.13.8
-ARG ALLURE_REPO=https://dl.bintray.com/qameta/maven/io/qameta/allure/allure-commandline
+ARG ALLURE_REPO=https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline
 ARG UID=1000
 ARG GID=1000
 

--- a/docker/Dockerfile.bionic
+++ b/docker/Dockerfile.bionic
@@ -4,7 +4,7 @@ ARG BUILD_DATE
 ARG BUILD_VERSION
 ARG BUILD_REF
 ARG ALLURE_RELEASE=NONE
-ARG ALLURE_REPO=https://dl.bintray.com/qameta/maven/io/qameta/allure/allure-commandline
+ARG ALLURE_REPO=https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline
 ARG QEMU_ARCH
 ARG UID=1000
 ARG GID=1000


### PR DESCRIPTION
Hi @fescobar.

The changes I made were:
- Added an extra parameter `report` to `emailable-report/export` and `emailable-report/render`. Default value: `latest`
- Added new parameter to swagger spec.
- Now emailable reports are saved with prefix `{REPORT}_...html`. <- I wonder if this change can break something. Maybe we shouldn't add a prefix when report it's the latest.

Solve #158 