### PR TITLE
Async report endpoint

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,14 +2,17 @@ name: Allure Docker Service Workflow
 
 on:
   push:
+    branches:
+      - "*"
+
     tags:
       - v*
 
   pull_request:
 
 env:
-  DOCKER_IMAGE: ghcr.io/hardnorth/allure-docker-service
-  ALLURE_RELEASE: 2.18.1
+  DOCKER_IMAGE: frankescobar/allure-docker-service
+  ALLURE_RELEASE: 2.17.2
   QEMU_VERSION: v4.0.0
   DOCKER_CLI_EXPERIMENTAL: enabled
 
@@ -106,11 +109,11 @@ jobs:
 
       - name: DockerHub Login
         if: success() && startsWith(github.ref, 'refs/tags/v')
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+          DOCKER_HUB_PASS: ${{ secrets.DOCKER_HUB_PASS }}
+        run: |
+          echo "${DOCKER_HUB_PASS}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
 
       - name: Docker Publishing
         if: success() && startsWith(github.ref, 'refs/tags/v')
@@ -129,11 +132,11 @@ jobs:
     steps:
       - name: DockerHub Login
         if: success() && startsWith(github.ref, 'refs/tags/v')
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+          DOCKER_HUB_PASS: ${{ secrets.DOCKER_HUB_PASS }}
+        run: |
+          echo "${DOCKER_HUB_PASS}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
 
       - name: Docker Publishing Manifest
         if: success() && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,9 +2,6 @@ name: Allure Docker Service Workflow
 
 on:
   push:
-    branches:
-      - "*"
-
     tags:
       - v*
 
@@ -109,8 +106,11 @@ jobs:
 
       - name: DockerHub Login
         if: success() && startsWith(github.ref, 'refs/tags/v')
-        run: |
-          run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Publishing
         if: success() && startsWith(github.ref, 'refs/tags/v')
@@ -129,8 +129,11 @@ jobs:
     steps:
       - name: DockerHub Login
         if: success() && startsWith(github.ref, 'refs/tags/v')
-        run: |
-          run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Publishing Manifest
         if: success() && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -109,11 +109,8 @@ jobs:
 
       - name: DockerHub Login
         if: success() && startsWith(github.ref, 'refs/tags/v')
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-          DOCKER_HUB_PASS: ${{ secrets.DOCKER_HUB_PASS }}
         run: |
-          echo "${DOCKER_HUB_PASS}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
+          run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Docker Publishing
         if: success() && startsWith(github.ref, 'refs/tags/v')
@@ -132,11 +129,8 @@ jobs:
     steps:
       - name: DockerHub Login
         if: success() && startsWith(github.ref, 'refs/tags/v')
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-          DOCKER_HUB_PASS: ${{ secrets.DOCKER_HUB_PASS }}
         run: |
-          echo "${DOCKER_HUB_PASS}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
+          run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Docker Publishing Manifest
         if: success() && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   DOCKER_IMAGE: frankescobar/allure-docker-service
-  ALLURE_RELEASE: 2.17.2
+  ALLURE_RELEASE: 2.18.1
   QEMU_VERSION: v4.0.0
   DOCKER_CLI_EXPERIMENTAL: enabled
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
 
 env:
-  DOCKER_IMAGE: ghcr.io/HardNorth/allure-docker-service
+  DOCKER_IMAGE: ghcr.io/hardnorth/allure-docker-service
   ALLURE_RELEASE: 2.18.1
   QEMU_VERSION: v4.0.0
   DOCKER_CLI_EXPERIMENTAL: enabled

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   DOCKER_IMAGE: ghcr.io/HardNorth/allure-docker-service
-  ALLURE_RELEASE: 2.17.2
+  ALLURE_RELEASE: 2.18.1
   QEMU_VERSION: v4.0.0
   DOCKER_CLI_EXPERIMENTAL: enabled
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
 
 env:
-  DOCKER_IMAGE: frankescobar/allure-docker-service
+  DOCKER_IMAGE: ghcr.io/HardNorth/allure-docker-service
   ALLURE_RELEASE: 2.17.2
   QEMU_VERSION: v4.0.0
   DOCKER_CLI_EXPERIMENTAL: enabled

--- a/allure-docker-api/.pylintrc
+++ b/allure-docker-api/.pylintrc
@@ -1,4 +1,5 @@
 [MASTER]
+ignore=venv
 disable=
     missing-module-docstring,
     missing-function-docstring,

--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -526,12 +526,13 @@ def jwt_refresh_token_required(fn): #pylint: disable=invalid-name, function-rede
     return wrapper
 
 @jwt.user_lookup_loader
-def user_loader_callback(identity):
-    if identity not in USERS_INFO:
+def user_loader_callback(_, identity):
+    username = identity['sub']
+    if username not in USERS_INFO:
         return None
     return UserAccess(
-        username=identity,
-        roles=USERS_INFO[identity]['roles']
+        username=username,
+        roles=USERS_INFO[username]['roles']
     )
 ### end Security Section
 

--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -76,7 +76,9 @@ app.config['JWT_REFRESH_TOKEN_EXPIRES'] = False
 
 DEV_MODE = 0
 HOST = '0.0.0.0'
-PORT = int(os.environ['PORT']) if os.environ['PORT'] else None
+PORT_STR = os.environ.get('PORT')
+PORT = int(PORT_STR) if PORT_STR else None
+ROOT_DIR = os.environ.get('ROOT', '/app')
 THREADS = 7
 URL_SCHEME = 'http'
 URL_PREFIX = ''
@@ -151,11 +153,11 @@ PROTECTED_ENDPOINTS = [
 REDIRECT_OUTPUT = '>'
 PROCESS_CHAIN = '&&'
 BACKGROUND_LOG_FILE_PATTERN = '{}/report_{}.log'
-GENERATE_REPORT_PROCESS = '{}/generateAllureReport.sh'.format(os.environ['ROOT'])
-KEEP_HISTORY_PROCESS = '{}/keepAllureHistory.sh'.format(os.environ['ROOT'])
-CLEAN_HISTORY_PROCESS = '{}/cleanAllureHistory.sh'.format(os.environ['ROOT'])
-CLEAN_RESULTS_PROCESS = '{}/cleanAllureResults.sh'.format(os.environ['ROOT'])
-RENDER_EMAIL_REPORT_PROCESS = '{}/renderEmailableReport.sh'.format(os.environ['ROOT'])
+GENERATE_REPORT_PROCESS = '{}/generateAllureReport.sh'.format(ROOT_DIR)
+KEEP_HISTORY_PROCESS = '{}/keepAllureHistory.sh'.format(ROOT_DIR)
+CLEAN_HISTORY_PROCESS = '{}/cleanAllureHistory.sh'.format(ROOT_DIR)
+CLEAN_RESULTS_PROCESS = '{}/cleanAllureResults.sh'.format(ROOT_DIR)
+RENDER_EMAIL_REPORT_PROCESS = '{}/renderEmailableReport.sh'.format(ROOT_DIR)
 ALLURE_VERSION = os.environ['ALLURE_VERSION']
 STATIC_CONTENT = os.environ['STATIC_CONTENT']
 PROJECTS_DIRECTORY = os.environ['STATIC_CONTENT_PROJECTS']
@@ -467,8 +469,8 @@ blacklist = set() #pylint: disable=invalid-name
 jwt = JWTManager(app) #pylint: disable=invalid-name
 
 @jwt.token_in_blocklist_loader
-def check_if_token_in_blacklist(decrypted_token):
-    jti = decrypted_token['jti']
+def check_if_token_in_blacklist(_, jwt_data):
+    jti = jwt_data['jti']
     return jti in blacklist
 
 @jwt.invalid_token_loader

--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -998,12 +998,13 @@ def generate_report_start_async_endpoint():
         exec_store_results_process = '1'
 
         call([KEEP_HISTORY_PROCESS, project_id, ORIGIN])
-        subprocess.Popen([
+        subprocess.Popen(
             " ".join([GENERATE_REPORT_PROCESS, exec_store_results_process, project_id, ORIGIN,
                       execution_name, execution_from, execution_type, REDIRECT_OUTPUT,
-                      BACKGROUND_LOG_FILE_PATTERN.format(project_path, project_id), PROCESS_CHAIN,
-                      RENDER_EMAIL_REPORT_PROCESS, project_id, ORIGIN])],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                      BACKGROUND_LOG_FILE_PATTERN.format(project_path, project_id),
+                      PROCESS_CHAIN,
+                      RENDER_EMAIL_REPORT_PROCESS, project_id, ORIGIN]),
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
     except Exception as ex:
         resp = get_error_response(ex)
     else:
@@ -1041,7 +1042,7 @@ def get_async_report_status_endpoint():
                 }
             }
             resp = jsonify(body)
-            resp.status_code = 102
+            resp.status_code = 202
             return resp
 
         project_path = get_project_path(project_id)
@@ -1057,7 +1058,7 @@ def get_async_report_status_endpoint():
         build_order = 'latest'
         for line in file_lines:
             if line.startswith("BUILD_ORDER"):
-                build_order = line[line.index(':') + 1: len(line)]
+                build_order = line[line.index(':') + 1: len(line)].strip()
 
         report_url = url_for('get_reports_endpoint', project_id=project_id,
                              path='{}/index.html'.format(build_order), _external=True)

--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -118,6 +118,16 @@ PROTECTED_ENDPOINTS = [
     },
     {
         "method": "get",
+        "path": "/generate-report/async",
+        "endpoint": "get_async_report_status_endpoint"
+    },
+    {
+        "method": "post",
+        "path": "/generate-report/async",
+        "endpoint": "generate_report_start_async_endpoint"
+    },
+    {
+        "method": "get",
         "path": "/clean-results",
         "endpoint": "clean_results_endpoint"
     },

--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -23,7 +23,7 @@ from flask.logging import create_logger
 from flask_swagger_ui import get_swaggerui_blueprint
 from flask_jwt_extended import (
     JWTManager, create_access_token, create_refresh_token, current_user, get_jwt_identity, verify_jwt_in_request,
-    get_raw_jwt, set_access_cookies, set_refresh_cookies, unset_jwt_cookies, verify_jwt_refresh_token_in_request
+    get_jwt, set_access_cookies, set_refresh_cookies, unset_jwt_cookies
 )
 
 dictConfig({
@@ -504,7 +504,7 @@ def jwt_refresh_token_required(fn): #pylint: disable=invalid-name, function-rede
     def wrapper(*args, **kwargs):
         if ENABLE_SECURITY_LOGIN:
             if is_endpoint_protected(request.endpoint):
-                verify_jwt_refresh_token_in_request()
+                verify_jwt_in_request(refresh=True)
         return fn(*args, **kwargs)
     return wrapper
 
@@ -614,7 +614,7 @@ def logout_endpoint():
         resp = jsonify(body)
         return resp, 404
     try:
-        jti = get_raw_jwt()['jti']
+        jti = get_jwt()['jti']
         blacklist.add(jti)
         return jsonify({'meta_data': {'message' : 'Successfully logged out'}}), 200
     except Exception as ex:
@@ -639,7 +639,7 @@ def logout_refresh_token_endpoint():
         resp = jsonify(body)
         return resp, 404
     try:
-        jti = get_raw_jwt()['jti']
+        jti = get_jwt()['jti']
         blacklist.add(jti)
         resp = jsonify({'meta_data': {'message' : 'Successfully logged out'}})
         unset_jwt_cookies(resp)

--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -22,9 +22,8 @@ from flask import (
 from flask.logging import create_logger
 from flask_swagger_ui import get_swaggerui_blueprint
 from flask_jwt_extended import (
-    JWTManager, jwt_required, create_access_token, create_refresh_token, current_user,
-    get_jwt_identity, verify_jwt_in_request, jwt_refresh_token_required, get_raw_jwt,
-    set_access_cookies, set_refresh_cookies, unset_jwt_cookies, verify_jwt_refresh_token_in_request
+    JWTManager, create_access_token, create_refresh_token, current_user, get_jwt_identity, verify_jwt_in_request,
+    get_raw_jwt, set_access_cookies, set_refresh_cookies, unset_jwt_cookies, verify_jwt_refresh_token_in_request
 )
 
 dictConfig({

--- a/allure-docker-api/app.py
+++ b/allure-docker-api/app.py
@@ -783,7 +783,8 @@ def latest_report_endpoint():
         return get_error_response(ex)
 
 
-ACCESS_FORBIDDEN_RESPONSE = get_response('Access Forbidden', 403)
+def get_access_forbidden_response():
+    return get_response('Access Forbidden', 403)
 
 
 @app.route("/send-results", methods=['POST'], strict_slashes=False)
@@ -796,7 +797,7 @@ def send_results_endpoint(): #pylint: disable=too-many-branches
     sent_files_count = None
     try:
         if check_admin_access(current_user) is False:
-            return ACCESS_FORBIDDEN_RESPONSE
+            return get_access_forbidden_response()
 
         content_type = str(request.content_type)
         if content_type is None:
@@ -881,7 +882,7 @@ def send_results_endpoint(): #pylint: disable=too-many-branches
 def generate_report_endpoint():
     try:
         if check_admin_access(current_user) is False:
-            return ACCESS_FORBIDDEN_RESPONSE
+            return get_access_forbidden_response()
 
         project_id = resolve_project(request.args.get('project_id'))
         if is_existent_project(project_id) is False:
@@ -966,7 +967,7 @@ ASYNC_REPORT_GENERATE_PATH = '/generate-report/async'
 def generate_report_start_async_endpoint():
     try:
         if check_admin_access(current_user) is False:
-            return ACCESS_FORBIDDEN_RESPONSE
+            return get_access_forbidden_response()
 
         project_id = resolve_project(request.args.get('project_id'))
         if is_existent_project(project_id) is False:
@@ -1026,7 +1027,7 @@ def generate_report_start_async_endpoint():
 def get_async_report_status_endpoint():
     try:
         if check_admin_access(current_user) is False:
-            return ACCESS_FORBIDDEN_RESPONSE
+            return get_access_forbidden_response()
 
         project_id = resolve_project(request.args.get('project_id'))
         if is_existent_project(project_id) is False:
@@ -1082,7 +1083,7 @@ def get_async_report_status_endpoint():
 def clean_history_endpoint():
     try:
         if check_admin_access(current_user) is False:
-            return ACCESS_FORBIDDEN_RESPONSE
+            return get_access_forbidden_response()
 
         project_id = resolve_project(request.args.get('project_id'))
         if is_existent_project(project_id) is False:
@@ -1110,7 +1111,7 @@ def clean_history_endpoint():
 def clean_results_endpoint():
     try:
         if check_admin_access(current_user) is False:
-            return ACCESS_FORBIDDEN_RESPONSE
+            return get_access_forbidden_response()
 
         project_id = resolve_project(request.args.get('project_id'))
         if is_existent_project(project_id) is False:
@@ -1243,7 +1244,7 @@ def report_export_endpoint():
 def create_project_endpoint():
     try:
         if check_admin_access(current_user) is False:
-            return ACCESS_FORBIDDEN_RESPONSE
+            return get_access_forbidden_response()
 
         if not request.is_json:
             raise Exception("Header 'Content-Type' is not 'application/json'")
@@ -1270,7 +1271,7 @@ def create_project_endpoint():
 def delete_project_endpoint(project_id):
     try:
         if check_admin_access(current_user) is False:
-            return ACCESS_FORBIDDEN_RESPONSE
+            return get_access_forbidden_response()
 
         if project_id == 'default':
             raise Exception("You must not remove project_id 'default'. Try with other projects")

--- a/allure-docker-api/requirements.txt
+++ b/allure-docker-api/requirements.txt
@@ -1,0 +1,3 @@
+Flask-JWT-Extended==3.25.1
+flask-swagger-ui
+waitress

--- a/allure-docker-api/requirements.txt
+++ b/allure-docker-api/requirements.txt
@@ -1,4 +1,7 @@
-flask==2.1.3
-Flask-JWT-Extended==4.4.2
-flask-swagger-ui
-waitress
+setuptools==57.0.0
+wheel==0.36.2
+flask==2.0.3
+Flask-JWT-Extended==4.3.1
+flask-swagger-ui==3.36.0
+waitress==2.0.0
+requests==2.23.0

--- a/allure-docker-api/requirements.txt
+++ b/allure-docker-api/requirements.txt
@@ -1,3 +1,4 @@
-Flask-JWT-Extended==3.25.1
+flask==2.1.3
+Flask-JWT-Extended==4.4.2
 flask-swagger-ui
 waitress

--- a/allure-docker-api/static/swagger/swagger.json
+++ b/allure-docker-api/static/swagger/swagger.json
@@ -218,11 +218,104 @@
          }
       },
       "/generate-report":{
-         "get":{
+         "get": {
             "tags":[
                "Action"
             ],
             "summary":"Generate new report",
+            "parameters":[
+               {
+                  "in":"query",
+                  "name":"project_id",
+                  "schema":{
+                     "type":"string"
+                  }
+               },
+               {
+                  "in":"query",
+                  "name":"execution_name",
+                  "schema":{
+                     "type":"string"
+                  }
+               },
+               {
+                  "in":"query",
+                  "name":"execution_from",
+                  "schema":{
+                     "type":"string"
+                  }
+               },
+               {
+                  "in":"query",
+                  "name":"execution_type",
+                  "schema":{
+                     "type":"string"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"OK",
+                  "schema":{
+                     "$ref":"#/components/schemas/response"
+                  }
+               },
+               "400":{
+                  "description":"BAD_REQUEST",
+                  "schema":{
+                     "$ref":"#/components/schemas/response"
+                  }
+               },
+               "404":{
+                  "description":"NOT_FOUND",
+                  "schema":{
+                     "$ref":"#/components/schemas/response"
+                  }
+               }
+            }
+         }
+      },
+      "/generate-report/async":{
+         "get":{
+            "tags":[
+               "Action"
+            ],
+            "summary":"Returns the last report generation status",
+            "parameters":[
+               {
+                  "in":"query",
+                  "name":"project_id",
+                  "schema":{
+                     "type":"string"
+                  }
+               }
+            ],
+            "responses":{
+               "200":{
+                  "description":"OK",
+                  "schema":{
+                     "$ref":"#/components/schemas/response"
+                  }
+               },
+               "400":{
+                  "description":"BAD_REQUEST",
+                  "schema":{
+                     "$ref":"#/components/schemas/response"
+                  }
+               },
+               "404":{
+                  "description":"NOT_FOUND",
+                  "schema":{
+                     "$ref":"#/components/schemas/response"
+                  }
+               }
+            }
+         },
+         "post": {
+            "tags":[
+               "Action"
+            ],
+            "summary":"Generate new report in asynchronous mode (return response immediately)",
             "parameters":[
                {
                   "in":"query",

--- a/allure-docker-api/static/swagger/swagger.json
+++ b/allure-docker-api/static/swagger/swagger.json
@@ -280,7 +280,7 @@
             "tags":[
                "Action"
             ],
-            "summary":"Returns the last report generation status",
+            "summary":"Returns the last asynchronous report generation status",
             "parameters":[
                {
                   "in":"query",

--- a/allure-docker-api/static/swagger/swagger.json
+++ b/allure-docker-api/static/swagger/swagger.json
@@ -292,19 +292,25 @@
             ],
             "responses":{
                "200":{
-                  "description":"OK",
+                  "description":"OK - Report generated",
                   "schema":{
                      "$ref":"#/components/schemas/response"
                   }
                },
-               "400":{
-                  "description":"BAD_REQUEST",
+               "202":{
+                  "description":"ACCEPTED - Process is still running",
+                  "schema":{
+                     "$ref":"#/components/schemas/response"
+                  }
+               },
+               "403":{
+                  "description":"FORBIDDEN - You do not have permissions to call the endpoint",
                   "schema":{
                      "$ref":"#/components/schemas/response"
                   }
                },
                "404":{
-                  "description":"NOT_FOUND",
+                  "description":"NOT_FOUND - No such job, project",
                   "schema":{
                      "$ref":"#/components/schemas/response"
                   }
@@ -347,20 +353,20 @@
                }
             ],
             "responses":{
-               "200":{
-                  "description":"OK",
+               "202":{
+                  "description":"ACCEPTED - Process is still running",
                   "schema":{
                      "$ref":"#/components/schemas/response"
                   }
                },
-               "400":{
-                  "description":"BAD_REQUEST",
+               "403":{
+                  "description":"FORBIDDEN - You do not have permissions to call the endpoint",
                   "schema":{
                      "$ref":"#/components/schemas/response"
                   }
                },
                "404":{
-                  "description":"NOT_FOUND",
+                  "description":"NOT_FOUND - No such job, project",
                   "schema":{
                      "$ref":"#/components/schemas/response"
                   }

--- a/docker/Dockerfile.bionic
+++ b/docker/Dockerfile.bionic
@@ -12,16 +12,19 @@ ARG GID=1000
 ######
 
 FROM python:3.6-alpine AS dev_stage
-RUN apk update
-RUN apk add build-base
-RUN pip install -U pylint
-RUN pip install -Iv setuptools==47.1.1 wheel==0.34.2 waitress==1.4.4 && \
-    pip install -Iv Flask==1.1.2 Flask-JWT-Extended==3.24.1 flask-swagger-ui==3.36.0 requests==2.23.0
-
 ENV ROOT_DIR=/code
 RUN mkdir -p $ROOT_DIR
 WORKDIR $ROOT_DIR
 COPY allure-docker-api $ROOT_DIR/allure-docker-api
+
+RUN apk update
+RUN apk add build-base
+RUN python -m pip install --upgrade pip && \
+    pip install -U pylint
+
+# Install requirements one-by-one to avoid ModuleNotFoundError 
+RUN grep -v '^#' allure-docker-api/requirements.txt | xargs -n1 pip install
+
 RUN pylint --rcfile=allure-docker-api/.pylintrc allure-docker-api
 
 ######
@@ -62,9 +65,7 @@ RUN apt-get update && \
       python3-dev \
       unzip && \
     ln -s `which python3` /usr/bin/python && \
-    pip3 install --upgrade pip && \
-    pip install -Iv setuptools==47.1.1 wheel==0.34.2 waitress==1.4.4 && \
-    pip install -Iv Flask==1.1.2 Flask-JWT-Extended==3.25.0 flask-swagger-ui==3.36.0 requests==2.23.0 && \
+    python -m pip install --upgrade pip && \
     curl ${ALLURE_REPO}/${ALLURE_RELEASE}/allure-commandline-${ALLURE_RELEASE}.zip -L -o /tmp/allure-commandline.zip && \
         unzip -q /tmp/allure-commandline.zip -d / && \
         apt-get remove -y unzip && \
@@ -105,6 +106,10 @@ RUN echo -n $(allure --version) > ${ALLURE_VERSION} && \
 WORKDIR $ROOT
 COPY --chown=allure:allure allure-docker-api $ROOT/allure-docker-api
 COPY --chown=allure:allure allure-docker-scripts $ROOT/
+
+# Install requirements one-by-one to avoid ModuleNotFoundError 
+RUN grep -v '^#' allure-docker-api/requirements.txt | xargs -n1 pip install
+
 RUN chmod +x $ROOT/*.sh && \
     mkdir $RESULTS_DIRECTORY && \
     mkdir -p $DEFAULT_PROJECT_REPORTS/latest && \


### PR DESCRIPTION
Starting from some amount of Test Cases (300 for my case) report generation begin taking time bigger than a minute. Since 
`allure-docker-service` does call on `allure-commandline` in a synchronous manner that drives me to a situation when my proxy (nginx) count such request as hanged and abort the connection with `504 Gateway Timeout`. Apparently that triggers a kill of the python process which handles generation request. And because `allure-docker-service` [communicate with the spawned proccess](https://github.com/fescobar/allure-docker-service/blob/master/allure-docker-api/app.py#L991) this process [receives `SIGPIPE` signal](https://stackoverflow.com/questions/22077881/yes-reporting-error-with-subprocess-communicate/22083141#22083141) and exits leaving report unfinished. My instance running on Kubernetes with many other stuff hanging around, and it's not possible to increase ingress proxt timeout just for the one pod and not for others.

This PR does the following things:
* Introduce 2 new endpoints: POST and GET for `/generate-report/async` path
  * POST `/generate-report/async` returns response immediately and not communicate with the spawned process so it's fully independent
  * GET `/generate-report/async` return the status of currently processed job: 202 for still processing and 200 for processed
* Documentation for these two methods above
* Allure version update
* Dependecies versions update: all Flask 1.* versions literally broken due to dependency deletion, so that has to be done just to bring it up again
* All dependencies moved to a single place: `requirements.txt` file; which is a standard file to store them
* Some code refactoring to reduce copy-paste


**PS**: Looks like the repo is out of support for a while. So for those who eagerly want my changes I built a package in my space: https://github.com/HardNorth/allure-docker-service/pkgs/container/allure-docker-service