### PR TITLE
#210, allow projectId to contain the string 'latest'

### DIFF
--- a/allure-docker-scripts/cleanAllureHistory.sh
+++ b/allure-docker-scripts/cleanAllureHistory.sh
@@ -14,7 +14,7 @@ if [ "$(ls -A $PROJECT_LATEST_REPORT | wc -l)" != "0" ]; then
 fi
 
 if [ "$(ls -A $PROJECT_REPORTS_DIRECTORY | wc -l)" != "0" ]; then
-    ls -d $PROJECT_REPORTS_DIRECTORY/* | grep -v latest | grep -wv 0 | xargs rm 2 -rf> /dev/null
+    ls -d $PROJECT_REPORTS_DIRECTORY/* | grep -v /latest | grep -wv 0 | xargs rm 2 -rf> /dev/null
 fi
 
 if [ -e $PROJECT_RESULTS_HISTORY ]; then

--- a/allure-docker-scripts/generateAllureReport.sh
+++ b/allure-docker-scripts/generateAllureReport.sh
@@ -12,7 +12,7 @@ EXECUTION_TYPE=$6
 PROJECT_REPORTS=$STATIC_CONTENT_PROJECTS/$PROJECT_ID/reports
 if [ "$(ls $PROJECT_REPORTS | wc -l)" != "0" ]; then
     if [ -e "$PROJECT_REPORTS/latest" ]; then
-        LAST_REPORT_PATH_DIRECTORY=$(ls -td $PROJECT_REPORTS/* | grep -v latest | grep -v $EMAILABLE_REPORT_FILE_NAME | head -1)
+        LAST_REPORT_PATH_DIRECTORY=$(ls -td $PROJECT_REPORTS/* | grep -v /latest | grep -v $EMAILABLE_REPORT_FILE_NAME | head -1)
     else
         LAST_REPORT_PATH_DIRECTORY=$(ls -td $PROJECT_REPORTS/* | grep -v $EMAILABLE_REPORT_FILE_NAME | head -1)
     fi

--- a/allure-docker-scripts/keepAllureLatestHistory.sh
+++ b/allure-docker-scripts/keepAllureLatestHistory.sh
@@ -8,11 +8,11 @@ if [ "$KEEP_HISTORY" == "TRUE" ] || [ "$KEEP_HISTORY" == "true" ] || [ "$KEEP_HI
     if echo $KEEP_HISTORY_LATEST | egrep -q '^[0-9]+$'; then
         KEEP_LATEST=$KEEP_HISTORY_LATEST
     fi
-    CURRENT_SIZE=$(ls -Ad $PROJECT_REPORTS_DIRECTORY/* | grep -v latest | grep -wv 0 | grep -v $EMAILABLE_REPORT_FILE_NAME | wc -l)
+    CURRENT_SIZE=$(ls -Ad $PROJECT_REPORTS_DIRECTORY/* | grep -v /latest | grep -wv 0 | grep -v $EMAILABLE_REPORT_FILE_NAME | wc -l)
 
     if [ "$CURRENT_SIZE" -gt "$KEEP_LATEST" ]; then
         SIZE_TO_REMOVE="$(($CURRENT_SIZE-$KEEP_LATEST))"
         echo "Keeping latest $KEEP_LATEST history reports for PROJECT_ID: $PROJECT_ID"
-        ls -tAd $PROJECT_REPORTS_DIRECTORY/* | grep -v latest | grep -wv 0 | grep -v $EMAILABLE_REPORT_FILE_NAME | tail -$SIZE_TO_REMOVE | xargs rm 2 -rf> /dev/null
+        ls -tAd $PROJECT_REPORTS_DIRECTORY/* | grep -v /latest | grep -wv 0 | grep -v $EMAILABLE_REPORT_FILE_NAME | tail -$SIZE_TO_REMOVE | xargs rm 2 -rf> /dev/null
     fi
 fi


### PR DESCRIPTION
Fixes #210 by updating the scripts so they work when the projectId contain the string 'latest' , as in projectId=foo-latestcommit