### PR TITLE
fixed cleaning of old reports when the project name contains "0"

### DIFF
--- a/allure-docker-scripts/keepAllureLatestHistory.sh
+++ b/allure-docker-scripts/keepAllureLatestHistory.sh
@@ -3,16 +3,16 @@
 PROJECT_ID=$1
 
 if [ "$KEEP_HISTORY" == "TRUE" ] || [ "$KEEP_HISTORY" == "true" ] || [ "$KEEP_HISTORY" == "1" ] ; then
-    PROJECT_REPORTS_DIRECTORY=$STATIC_CONTENT_PROJECTS/$PROJECT_ID/reports
+    cd "$STATIC_CONTENT_PROJECTS"/"$PROJECT_ID"/ || exit
     KEEP_LATEST="20"
     if echo $KEEP_HISTORY_LATEST | egrep -q '^[0-9]+$'; then
         KEEP_LATEST=$KEEP_HISTORY_LATEST
     fi
-    CURRENT_SIZE=$(ls -Ad $PROJECT_REPORTS_DIRECTORY/* | grep -wv $PROJECT_REPORTS_DIRECTORY/latest | grep -wv 0 | grep -v $EMAILABLE_REPORT_FILE_NAME | wc -l)
+    CURRENT_SIZE=$(ls -Ad reports/* | grep -wv reports/latest | grep -wv 0 | grep -v $EMAILABLE_REPORT_FILE_NAME | wc -l)
 
     if [ "$CURRENT_SIZE" -gt "$KEEP_LATEST" ]; then
         SIZE_TO_REMOVE="$(($CURRENT_SIZE-$KEEP_LATEST))"
         echo "Keeping latest $KEEP_LATEST history reports for PROJECT_ID: $PROJECT_ID"
-        ls -tAd $PROJECT_REPORTS_DIRECTORY/* | grep -wv $PROJECT_REPORTS_DIRECTORY/latest | grep -wv 0 | grep -v $EMAILABLE_REPORT_FILE_NAME | tail -$SIZE_TO_REMOVE | xargs rm 2 -rf> /dev/null
+        ls -tAd reports/* | grep -wv reports/latest | grep -wv 0 | grep -v $EMAILABLE_REPORT_FILE_NAME | tail -$SIZE_TO_REMOVE | xargs rm 2 -rf> /dev/null
     fi
 fi


### PR DESCRIPTION
Fixing: https://github.com/fescobar/allure-docker-service/issues/253