### PR TITLE
Updating Allure Framework version 2.30.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   DOCKER_IMAGE: frankescobar/allure-docker-service
-  ALLURE_RELEASE: 2.27.0
+  ALLURE_RELEASE: 2.30.0
   QEMU_VERSION: v4.0.0
   DOCKER_CLI_EXPERIMENTAL: enabled
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ The following table shows the variation of provided images.
 
 The following table shows the provided Manifest Lists.
 
-| **Tag**                                | **allure-docker-service Base Image**              |
-|----------------------------------------|---------------------------------------------------|
-| latest, 2.27.0                         | frankescobar/allure-docker-service:2.27.0-amd64   |
-|                                        | frankescobar/allure-docker-service:2.27.0-arm32v7 |
-|                                        | frankescobar/allure-docker-service:2.27.0-arm64v8 |
+| **Tag**        | **allure-docker-service Base Image**              |
+|----------------|---------------------------------------------------|
+| latest, 2.30.0 | frankescobar/allure-docker-service:2.30.0-amd64   |
+|                | frankescobar/allure-docker-service:2.30.0-arm32v7 |
+|                | frankescobar/allure-docker-service:2.30.0-arm64v8 |
 
 ## USAGE
 ### Generate Allure Results
@@ -722,7 +722,7 @@ You can switch the version container using `frankescobar/allure-docker-service:$
 Docker Compose example:
 ```sh
   allure:
-    image: "frankescobar/allure-docker-service:2.27.0"
+    image: "frankescobar/allure-docker-service:2.30.0"
 ```
 or using latest version:
 
@@ -1395,7 +1395,7 @@ docker-compose -f docker-compose-dev.yml up --build
 ```
 ### Build image
 ```sh
-docker build -t allure-release -f docker-custom/Dockerfile.bionic-custom --build-arg ALLURE_RELEASE=2.27.0 .
+docker build -t allure-release -f docker-custom/Dockerfile.bionic-custom --build-arg ALLURE_RELEASE=2.30.0 .
 ```
 ### Run container
 ```sh
@@ -1446,5 +1446,5 @@ docker run -d  -p 5050:5050 frankescobar/allure-docker-service
 ```
 ### Download specific tagged image registered (Example)
 ```sh
-docker run -d -p 5050:5050 frankescobar/allure-docker-service:2.27.0
+docker run -d -p 5050:5050 frankescobar/allure-docker-service:2.30.0
 ```

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,7 +10,7 @@ services:
       context: ../allure-docker-service
       dockerfile: docker-custom/Dockerfile.bionic-custom
       args:
-        ALLURE_RELEASE: "2.27.0"
+        ALLURE_RELEASE: "2.30.0"
     environment:
       DEV_MODE: 0
       CHECK_RESULTS_EVERY_SECONDS: NONE

--- a/docker-custom/Dockerfile.bionic-custom
+++ b/docker-custom/Dockerfile.bionic-custom
@@ -1,9 +1,9 @@
 ARG ARCH=amd64
 ARG JDK=adoptopenjdk:11-jre-openj9-bionic
 ARG BUILD_DATE
-ARG BUILD_VERSION=2.27.0-custom
+ARG BUILD_VERSION=2.30.0-custom
 ARG BUILD_REF=na
-ARG ALLURE_RELEASE=2.27.0
+ARG ALLURE_RELEASE=2.30.0
 ARG ALLURE_REPO=https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline
 ARG UID=1000
 ARG GID=1000


### PR DESCRIPTION
Allure 2.30.0 has this important feature implemented (https://github.com/allure-framework/allure2/issues/889), that is especially useful in docker / k8s environment: allows to properly track test execution using Prometheus.