### PR TITLE
Allowed compressed result file upload #149 using two approaches : archived data in form-data or archived data in body

### DIFF
--- a/allure-docker-api-usage/send_results.sh
+++ b/allure-docker-api-usage/send_results.sh
@@ -22,6 +22,11 @@ done
 set -o xtrace
 echo "------------------SEND-RESULTS------------------"
 curl -X POST "$ALLURE_SERVER/allure-docker-service/send-results?project_id=$PROJECT_ID" -H 'Content-Type: multipart/form-data' $FILES -ik
+# send archived allure-results files with form-data
+#curl -X POST "$ALLURE_SERVER/allure-docker-service/send-results?project_id=$PROJECT_ID" -H 'Content-Type: multipart/form-data' "-F zip=allure-results-example/allure-results-example.zip" -ik
+# send archived allure-results as body
+#curl -X POST "$ALLURE_SERVER/allure-docker-service/send-results?project_id=$PROJECT_ID" -H 'Content-Type: application/zip' --data-binary @'allure-results-example/allure-results-example.zip' -ik
+#curl -X POST "$ALLURE_SERVER/allure-docker-service/send-results?project_id=$PROJECT_ID" -H 'Content-Type: application/gzip' --data-binary @'allure-results-example/allure-results-example.tar.gz' -ik
 
 
 #If you want to generate reports on demand use the endpoint `GET /generate-report` and disable the Automatic Execution >> `CHECK_RESULTS_EVERY_SECONDS: NONE`

--- a/allure-docker-api/static/swagger/swagger.json
+++ b/allure-docker-api/static/swagger/swagger.json
@@ -141,7 +141,9 @@
             "summary":"Send results files (from version 2.12.1)",
             "consumes":[
                "application/json",
-               "multipart/form-data"
+               "multipart/form-data",
+               "application/zip",
+               "application/gzip"
             ],
             "parameters":[
                {
@@ -188,6 +190,18 @@
                   "multipart/form-data":{
                      "schema":{
                         "$ref":"#/components/schemas/files"
+                     }
+                  },
+                  "application/zip": {
+                     "schema": {
+                        "type": "string",
+                        "format": "binary"
+                     }
+                  },
+                  "application/gzip": {
+                     "schema": {
+                        "type": "string",
+                        "format": "binary"
                      }
                   }
                }
@@ -773,13 +787,17 @@
          },
          "files":{
             "type":"object",
-            "properties":{
+            "properties": {
                "files[]":{
                   "type":"array",
                   "items":{
                      "type":"string",
                      "format":"binary"
                   }
+               },
+               "zip": {
+                  "type": "string",
+                  "format": "binary"
                }
             }
          }


### PR DESCRIPTION
added new logic to upload allure results:

1. create zip archive with all allure results files. 
2. upload zip archive using two different options
3. send zip archive via POST /send-results `curl -X POST "$ALLURE_SERVER/allure-docker-service/send-results?project_id=$PROJECT_ID" -H 'Content-Type: multipart/form-data' "-F zip=allure-results-example/allure-results-example.zip" -ik`
4. or send zip archive via POST /send-results with Content-Type: application/zip and zip archive as body
`curl -X POST "$ALLURE_SERVER/allure-docker-service/send-results?project_id=$PROJECT_ID" -H 'Content-Type: application/zip' --data-binary @'allure-results-example/allure-results-example.zip' -ik`

also tar.gz can be used to POST data to /send-results:
`curl -X POST "$ALLURE_SERVER/allure-docker-service/send-results?project_id=$PROJECT_ID" -H 'Content-Type: application/gzip' --data-binary @'allure-results-example/allure-results-example.tar.gz' -ik`