### PR TITLE
Update Dockerfile - to use specific image versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG JDK=eclipse-temurin:11-jre-noble
+ARG JDK=eclipse-temurin:11.0.29_7-jre-noble
 ARG BUILD_DATE
 ARG BUILD_VERSION
 ARG BUILD_REF
@@ -10,7 +10,7 @@ ARG PYTHON_VERSION=3.13
 
 ######
 
-FROM python:${PYTHON_VERSION}-alpine AS dev_stage
+FROM python:${PYTHON_VERSION}.11-alpine3.23 AS dev_stage
 RUN apk update
 RUN apk add build-base
 RUN pip install -U pylint


### PR DESCRIPTION
This will update the base images used to build this repo's image and will help with future traceability, as both

eclipse-temurin:11-jre-noble

and

python:3.13-alpine

tags get reused as the base images are updated and we lose understanding of precisely which base image version was used and whether it needs updating.