### PR TITLE
updating base image and allure-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1395,7 +1395,7 @@ docker-compose -f docker-compose-dev.yml up --build
 ```
 ### Build image
 ```sh
-docker build --no-cache -t allure-release -f docker/Dockerfile --build-arg ALLURE_RELEASE=2.35.1 .
+docker build --no-cache -t allure-release -f docker/Dockerfile --build-arg ALLURE_RELEASE=2.36.0 .
 ```
 ### Run container
 ```sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG JDK=eclipse-temurin:11-jre-noble
+ARG JDK=eclipse-temurin:11.0.30_7-jre-noble
 ARG BUILD_DATE
 ARG BUILD_VERSION
 ARG BUILD_REF
@@ -6,16 +6,17 @@ ARG ALLURE_RELEASE=NONE
 ARG ALLURE_REPO=https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline
 ARG UID=1000
 ARG GID=1000
-ARG PYTHON_VERSION=3.13
+ARG PYTHON_VERSION=3.13.12
 
 ######
 
-FROM python:${PYTHON_VERSION}-alpine AS dev_stage
+FROM python:${PYTHON_VERSION}-alpine3.23 AS dev_stage
 RUN apk update
 RUN apk add build-base
 RUN pip install -U pylint
-RUN pip install --upgrade pip==25.2 setuptools==80.9.0 wheel==0.45.1 waitress==3.0.2 && \
-    pip install -Iv Flask==3.1.2 Flask-JWT-Extended==4.7.1 flask-swagger-ui==4.11.1 requests==2.32.5
+RUN pip install --upgrade pip==26.0.1 setuptools==82.0.0 wheel==0.46.2 waitress==3.0.2 && \
+    pip install -Iv Flask==3.1.2 Flask-JWT-Extended==4.7.1 flask-swagger-ui==4.11.1 requests==2.32.5 && \
+    rm -rf /root/.cache/pip
 
 ENV ROOT_DIR=/code
 RUN mkdir -p $ROOT_DIR
@@ -64,8 +65,9 @@ RUN apt-get update && \
     sed -i "s/\"--force-reinstall\"/\"--force-reinstall\", \"--break-system-packages\"/g" get-pip.py && \
     python${PYTHON_VERSION} get-pip.py && \
     python${PYTHON_VERSION} -m pip config set global.break-system-packages true && \
-    python${PYTHON_VERSION} -m pip install setuptools==80.9.0 wheel==0.45.1 waitress==3.0.2 pipdeptree==2.29.0 cffi==2.0.0 cryptography==46.0.3 && \
+    python${PYTHON_VERSION} -m pip install setuptools==82.0.0 wheel==0.46.2 waitress==3.0.2 pipdeptree==2.29.0 cffi==2.0.0 cryptography==46.0.3 && \
     python${PYTHON_VERSION} -m pip install --ignore-installed --upgrade Flask==3.1.2 Flask-JWT-Extended==4.7.1 flask-swagger-ui==4.11.1 requests==2.32.5 && \
+    rm -rf /root/.cache/pip && \
     curl ${ALLURE_REPO}/${ALLURE_RELEASE}/allure-commandline-${ALLURE_RELEASE}.zip -L -o /tmp/allure-commandline.zip && \
         unzip -q /tmp/allure-commandline.zip -d / && \
         apt-get remove -y unzip && \


### PR DESCRIPTION
Have done following to address vulnerabilities in the image:

 - updated the images used in dockerfile
 -  updated setuptools and wheel python libraries
 - used version 2.36.0 of allure-release
 - added cache cleanup `rm -rf /root/.cache/pip`
