### PR TITLE
Introduce the Helm Chart

### DIFF
--- a/charts/allure-docker-service/Chart.yaml
+++ b/charts/allure-docker-service/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: allure-docker-service
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "2.38.1"

--- a/charts/allure-docker-service/templates/NOTES.txt
+++ b/charts/allure-docker-service/templates/NOTES.txt
@@ -1,0 +1,47 @@
+Allure Docker Service has been deployed.
+
+1. API endpoint:
+{{- if .Values.api.ingress.enabled }}
+  http{{ if .Values.api.ingress.tls }}s{{ end }}://{{ (first .Values.api.ingress.hosts).host }}
+{{- else if eq .Values.api.service.type "NodePort" }}
+  export NODE_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "allure-docker-service.api.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "API: http://$NODE_IP:$NODE_PORT"
+{{- else if eq .Values.api.service.type "LoadBalancer" }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be assigned.
+  kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "allure-docker-service.api.fullname" . }}
+{{- else }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} \
+    svc/{{ include "allure-docker-service.api.fullname" . }} 5050:{{ .Values.api.service.port }}
+  echo "API: http://127.0.0.1:5050"
+{{- end }}
+
+2. API credentials:
+{{- if .Values.api.security.existingSecret }}
+   Using existing Secret: {{ .Values.api.security.existingSecret }}
+{{- else }}
+   A Secret named {{ include "allure-docker-service.api.fullname" . }} was created
+   with auto-generated credentials. Retrieve them with:
+
+     kubectl get secret --namespace {{ .Release.Namespace }} \
+       {{ include "allure-docker-service.api.fullname" . }} \
+       -o jsonpath="{.data.user}" | base64 -d; echo
+     kubectl get secret --namespace {{ .Release.Namespace }} \
+       {{ include "allure-docker-service.api.fullname" . }} \
+       -o jsonpath="{.data.password}" | base64 -d; echo
+
+   To supply your own credentials instead of auto-generated ones:
+
+     api:
+       security:
+         user: "my_username"
+         password: "my_password"
+         viewerUser: "view_user"
+         viewerPassword: "view_pass"
+
+   To reference a pre-existing Secret and skip Secret creation entirely:
+
+     api:
+       security:
+         existingSecret: "<your-secret-name>"
+{{- end }}

--- a/charts/allure-docker-service/templates/_helpers.tpl
+++ b/charts/allure-docker-service/templates/_helpers.tpl
@@ -1,0 +1,149 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "allure-docker-service.name" -}}
+{{- default .Chart.Name .Values.global.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "allure-docker-service.fullname" -}}
+{{- if .Values.global.fullnameOverride }}
+{{- .Values.global.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.global.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label.
+*/}}
+{{- define "allure-docker-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels (chart-wide, used for resources that span components such as ServiceAccount).
+*/}}
+{{- define "allure-docker-service.commonLabels" -}}
+helm.sh/chart: {{ include "allure-docker-service.chart" . }}
+app.kubernetes.io/name: {{ include "allure-docker-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "allure-docker-service.serviceAccountName" -}}
+{{- if .Values.global.serviceAccount.create }}
+{{- default (include "allure-docker-service.fullname" .) .Values.global.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.global.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/* ------------------------------------------------------------------ */}}
+{{/*  API component                                                       */}}
+{{/* ------------------------------------------------------------------ */}}
+
+{{/*
+API fully-qualified name.
+*/}}
+{{- define "allure-docker-service.api.fullname" -}}
+{{- printf "%s-api" (include "allure-docker-service.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+API selector labels.
+*/}}
+{{- define "allure-docker-service.api.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "allure-docker-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: api
+{{- end }}
+
+{{/*
+API labels (selector labels + chart metadata).
+*/}}
+{{- define "allure-docker-service.api.labels" -}}
+helm.sh/chart: {{ include "allure-docker-service.chart" . }}
+{{ include "allure-docker-service.api.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+API image reference — prepends the global registry when set.
+Falls back to Chart.AppVersion when image.tag is not specified.
+*/}}
+{{- define "allure-docker-service.api.image" -}}
+{{- $registry := .Values.global.image.registry -}}
+{{- $repo     := .Values.api.image.repository -}}
+{{- $tag      := .Values.api.image.tag | default .Chart.AppVersion -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/* ------------------------------------------------------------------ */}}
+{{/*  UI component                                                        */}}
+{{/* ------------------------------------------------------------------ */}}
+
+{{/*
+UI fully-qualified name.
+*/}}
+{{- define "allure-docker-service.ui.fullname" -}}
+{{- printf "%s-ui" (include "allure-docker-service.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+UI selector labels.
+*/}}
+{{- define "allure-docker-service.ui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "allure-docker-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: ui
+{{- end }}
+
+{{/*
+UI labels (selector labels + chart metadata).
+*/}}
+{{- define "allure-docker-service.ui.labels" -}}
+helm.sh/chart: {{ include "allure-docker-service.chart" . }}
+{{ include "allure-docker-service.ui.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+UI image reference — prepends the global registry when set.
+Falls back to Chart.AppVersion when image.tag is not specified.
+*/}}
+{{- define "allure-docker-service.ui.image" -}}
+{{- $registry := .Values.global.image.registry -}}
+{{- $repo     := .Values.ui.image.repository -}}
+{{- $tag      := .Values.ui.image.tag | default .Chart.AppVersion -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end }}

--- a/charts/allure-docker-service/templates/api-deployment.yaml
+++ b/charts/allure-docker-service/templates/api-deployment.yaml
@@ -1,0 +1,142 @@
+{{- if .Values.api.enabled -}}
+{{/*
+  Build the default environment variables for the API container.
+  These are the operational defaults derived from docker-compose-dev.yml.
+
+  Merge strategy: user values win.
+    1. Collect the names of every env var the user declared in podEnvs.
+    2. Keep only the defaults whose name is NOT in that set.
+    3. Concat filtered defaults with podEnvs — user entries always appear last
+       and therefore shadow any remaining duplicate that could sneak in.
+
+  Credentials (SECURITY_USER/PASS, viewer pair) are injected from the managed
+  Secret via secretKeyRef — see api-secrets.yaml and api.security in values.
+  URL_PREFIX defaults to an empty string (root). Override via podEnvs to serve
+  the API under a sub-path, e.g.: - name: URL_PREFIX\n      value: "/my-prefix"
+*/}}
+{{- $defaults := list
+  (dict "name" "DEV_MODE"                    "value" "0")
+  (dict "name" "CHECK_RESULTS_EVERY_SECONDS" "value" "NONE")
+  (dict "name" "KEEP_HISTORY"                "value" "1")
+  (dict "name" "KEEP_HISTORY_LATEST"         "value" "5")
+  (dict "name" "SECURITY_ENABLED"            "value" "1")
+  (dict "name" "MAKE_VIEWER_ENDPOINTS_PUBLIC" "value" "0")
+  (dict "name" "OPTIMIZE_STORAGE"            "value" "0")
+  (dict "name" "API_RESPONSE_LESS_VERBOSE"   "value" "0")
+  (dict "name" "TLS"                         "value" "0")
+  (dict "name" "URL_PREFIX"                  "value" "")
+-}}
+{{- $userEnvNames := list -}}
+{{- range .Values.api.podEnvs -}}
+{{- $userEnvNames = append $userEnvNames .name -}}
+{{- end -}}
+{{- $filteredDefaults := list -}}
+{{- range $defaults -}}
+{{- if not (has .name $userEnvNames) -}}
+{{- $filteredDefaults = append $filteredDefaults . -}}
+{{- end -}}
+{{- end -}}
+{{- $allEnvs := concat $filteredDefaults .Values.api.podEnvs -}}
+{{- $secretName := .Values.api.security.existingSecret | default (include "allure-docker-service.api.fullname" .) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "allure-docker-service.api.fullname" . }}
+  labels:
+    {{- include "allure-docker-service.api.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "allure-docker-service.api.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.api.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "allure-docker-service.api.selectorLabels" . | nindent 8 }}
+        {{- with .Values.api.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.global.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "allure-docker-service.serviceAccountName" . }}
+      {{- with .Values.api.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: api
+          {{- with .Values.api.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: {{ include "allure-docker-service.api.image" . }}
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 5050
+              protocol: TCP
+          env:
+            - name: SECURITY_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: user
+            - name: SECURITY_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: password
+            - name: SECURITY_VIEWER_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: viewerUser
+            - name: SECURITY_VIEWER_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: viewerPassword
+            {{- toYaml $allEnvs | nindent 12 }}
+          {{- with .Values.api.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.api.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.api.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.api.persistence.enabled }}
+          volumeMounts:
+            - name: allure-results
+              mountPath: /app/allure-results
+          {{- end }}
+      {{- if .Values.api.persistence.enabled }}
+      volumes:
+        - name: allure-results
+          persistentVolumeClaim:
+            claimName: {{ include "allure-docker-service.api.fullname" . }}
+      {{- end }}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/allure-docker-service/templates/api-httproute.yaml
+++ b/charts/allure-docker-service/templates/api-httproute.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.api.enabled .Values.api.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "allure-docker-service.api.fullname" . }}
+  labels:
+    {{- include "allure-docker-service.api.labels" . | nindent 4 }}
+  {{- with .Values.api.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.api.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.api.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- toYaml .Values.api.httpRoute.rules | nindent 4 }}
+{{- end }}

--- a/charts/allure-docker-service/templates/api-ingress.yaml
+++ b/charts/allure-docker-service/templates/api-ingress.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.api.enabled .Values.api.ingress.enabled -}}
+{{- $fullName := include "allure-docker-service.api.fullname" . -}}
+{{- $svcPort  := .Values.api.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "allure-docker-service.api.labels" . | nindent 4 }}
+  {{- with .Values.api.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.api.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.api.ingress.tls }}
+  tls:
+    {{- toYaml .Values.api.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.api.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/allure-docker-service/templates/api-pvc.yaml
+++ b/charts/allure-docker-service/templates/api-pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.api.enabled .Values.api.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "allure-docker-service.api.fullname" . }}
+  labels:
+    {{- include "allure-docker-service.api.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.api.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.api.persistence.size }}
+  {{- with .Values.api.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/allure-docker-service/templates/api-secrets.yaml
+++ b/charts/allure-docker-service/templates/api-secrets.yaml
@@ -1,0 +1,67 @@
+{{- if and .Values.api.enabled (not .Values.api.security.existingSecret) -}}
+{{/*
+  Stable-random Secret for API credentials.
+
+  Lookup strategy (preserves values across helm upgrade):
+    1. If the user set a value in api.security.*, use it.
+    2. Else if the Secret already exists in the cluster, keep the stored value.
+    3. Else generate a random 16-character alphanumeric string.
+
+  Note: `helm template` always skips the lookup (no cluster connection), so
+  rendered output will show freshly generated randoms — this is expected and
+  harmless because `helm install/upgrade` will use the stable lookup path.
+*/}}
+{{- $existingData := dict -}}
+{{- with lookup "v1" "Secret" .Release.Namespace (include "allure-docker-service.api.fullname" .) -}}
+{{- $existingData = .data | default dict -}}
+{{- end -}}
+
+{{- $user := "" -}}
+{{- if .Values.api.security.user -}}
+{{- $user = .Values.api.security.user -}}
+{{- else if hasKey $existingData "user" -}}
+{{- $user = index $existingData "user" | b64dec -}}
+{{- else -}}
+{{- $user = randAlphaNum 16 -}}
+{{- end -}}
+
+{{- $password := "" -}}
+{{- if .Values.api.security.password -}}
+{{- $password = .Values.api.security.password -}}
+{{- else if hasKey $existingData "password" -}}
+{{- $password = index $existingData "password" | b64dec -}}
+{{- else -}}
+{{- $password = randAlphaNum 16 -}}
+{{- end -}}
+
+{{- $viewerUser := "" -}}
+{{- if .Values.api.security.viewerUser -}}
+{{- $viewerUser = .Values.api.security.viewerUser -}}
+{{- else if hasKey $existingData "viewerUser" -}}
+{{- $viewerUser = index $existingData "viewerUser" | b64dec -}}
+{{- else -}}
+{{- $viewerUser = randAlphaNum 16 -}}
+{{- end -}}
+
+{{- $viewerPassword := "" -}}
+{{- if .Values.api.security.viewerPassword -}}
+{{- $viewerPassword = .Values.api.security.viewerPassword -}}
+{{- else if hasKey $existingData "viewerPassword" -}}
+{{- $viewerPassword = index $existingData "viewerPassword" | b64dec -}}
+{{- else -}}
+{{- $viewerPassword = randAlphaNum 16 -}}
+{{- end -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "allure-docker-service.api.fullname" . }}
+  labels:
+    {{- include "allure-docker-service.api.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  user: {{ $user | quote }}
+  password: {{ $password | quote }}
+  viewerUser: {{ $viewerUser | quote }}
+  viewerPassword: {{ $viewerPassword | quote }}
+{{- end }}

--- a/charts/allure-docker-service/templates/api-service.yaml
+++ b/charts/allure-docker-service/templates/api-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.api.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "allure-docker-service.api.fullname" . }}
+  labels:
+    {{- include "allure-docker-service.api.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.api.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.api.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "allure-docker-service.api.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/allure-docker-service/templates/serviceaccount.yaml
+++ b/charts/allure-docker-service/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.global.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "allure-docker-service.serviceAccountName" . }}
+  labels:
+    {{- include "allure-docker-service.commonLabels" . | nindent 4 }}
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.global.serviceAccount.automount }}
+{{- end }}

--- a/charts/allure-docker-service/templates/ui-deployment.yaml
+++ b/charts/allure-docker-service/templates/ui-deployment.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.ui.enabled -}}
+{{/*
+  Build the default environment variables for the UI container.
+
+  ALLURE_DOCKER_PUBLIC_API_URL_PREFIX defaults to an empty string, matching
+  the docker-compose default. Override via podEnvs if a URL prefix is needed.
+
+  ALLURE_DOCKER_PUBLIC_API_URL defaults to the scheme + first host from
+  ui.ingress.hosts[0].host (http:// or https:// based on whether ingress TLS
+  is configured). Override via podEnvs to supply a different URL.
+*/}}
+{{- $apiHost := "" -}}
+{{- if .Values.ui.ingress.hosts -}}
+{{- $apiHost = (first .Values.ui.ingress.hosts).host -}}
+{{- end -}}
+{{- $apiScheme := "http" -}}
+{{- if .Values.ui.ingress.tls -}}
+{{- $apiScheme = "https" -}}
+{{- end -}}
+{{- $apiUrl := printf "%s://%s" $apiScheme $apiHost -}}
+{{- $defaults := list
+  (dict "name" "ALLURE_DOCKER_PUBLIC_API_URL_PREFIX" "value" "")
+  (dict "name" "ALLURE_DOCKER_PUBLIC_API_URL" "value" $apiUrl)
+-}}
+{{- $userEnvNames := list -}}
+{{- range .Values.ui.podEnvs -}}
+{{- $userEnvNames = append $userEnvNames .name -}}
+{{- end -}}
+{{- $filteredDefaults := list -}}
+{{- range $defaults -}}
+{{- if not (has .name $userEnvNames) -}}
+{{- $filteredDefaults = append $filteredDefaults . -}}
+{{- end -}}
+{{- end -}}
+{{- $allEnvs := concat $filteredDefaults .Values.ui.podEnvs -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "allure-docker-service.ui.fullname" . }}
+  labels:
+    {{- include "allure-docker-service.ui.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.ui.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "allure-docker-service.ui.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.ui.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "allure-docker-service.ui.selectorLabels" . | nindent 8 }}
+        {{- with .Values.ui.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.global.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "allure-docker-service.serviceAccountName" . }}
+      {{- with .Values.ui.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: ui
+          {{- with .Values.ui.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: {{ include "allure-docker-service.ui.image" . }}
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 5252
+              protocol: TCP
+          env:
+            {{- toYaml $allEnvs | nindent 12 }}
+          {{- with .Values.ui.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ui.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ui.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.ui.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ui.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ui.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/allure-docker-service/templates/ui-httproute.yaml
+++ b/charts/allure-docker-service/templates/ui-httproute.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.ui.enabled .Values.ui.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "allure-docker-service.ui.fullname" . }}
+  labels:
+    {{- include "allure-docker-service.ui.labels" . | nindent 4 }}
+  {{- with .Values.ui.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.ui.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.ui.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- toYaml .Values.ui.httpRoute.rules | nindent 4 }}
+{{- end }}

--- a/charts/allure-docker-service/templates/ui-ingress.yaml
+++ b/charts/allure-docker-service/templates/ui-ingress.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.ui.enabled .Values.ui.ingress.enabled -}}
+{{- $fullName := include "allure-docker-service.ui.fullname" . -}}
+{{- $svcPort  := .Values.ui.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "allure-docker-service.ui.labels" . | nindent 4 }}
+  {{- with .Values.ui.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ui.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ui.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ui.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ui.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/allure-docker-service/templates/ui-service.yaml
+++ b/charts/allure-docker-service/templates/ui-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ui.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "allure-docker-service.ui.fullname" . }}
+  labels:
+    {{- include "allure-docker-service.ui.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.ui.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.ui.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "allure-docker-service.ui.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/allure-docker-service/values.yaml
+++ b/charts/allure-docker-service/values.yaml
@@ -1,0 +1,150 @@
+global:
+  image:
+    registry: "docker.io"
+    imagePullSecrets: []
+
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: false
+    automount: false
+    annotations: {}
+    name: ""
+
+api:
+  enabled: true
+  replicaCount: 1
+
+  image:
+    repository: "frankescobar/allure-docker-service"
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  podAnnotations: {}
+  podLabels: {}
+  podEnvs: []
+  podSecurityContext: {}
+  securityContext: {}
+
+  # Credentials are stored in a managed Secret (see api-secrets.yaml template).
+  # Leave a field empty to have Helm auto-generate a random 16-char value on
+  # first install; existing values are preserved on subsequent upgrades.
+  # Set existingSecret to skip Secret creation and reference your own instead.
+  security:
+    existingSecret: ""
+    user: ""
+    password: ""
+    viewerUser: ""
+    viewerPassword: ""
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: allure.localhost
+        paths:
+          - path: /allure-docker-service
+            pathType: ImplementationSpecific
+    tls: []
+
+  httpRoute:
+    enabled: false
+    annotations: {}
+    parentRefs:
+      - name: gateway
+        namespace: default
+        sectionName: http
+    hostnames:
+      - allure.localhost
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /api
+
+  resources: {}
+
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+
+  persistence:
+    enabled: false
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    storageClass: ""
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+ui:
+  enabled: true
+  replicaCount: 1
+
+  image:
+    repository: "frankescobar/allure-docker-service-ui"
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  podAnnotations: {}
+  podLabels: {}
+  podEnvs: []
+  podSecurityContext: {}
+  securityContext: {}
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: allure.localhost
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+
+  httpRoute:
+    enabled: false
+    annotations: {}
+    parentRefs:
+      - name: gateway
+        namespace: default
+        sectionName: http
+    hostnames:
+      - allure.localhost
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+
+  resources: {}
+
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+  readinessProbe:
+    httpGet:
+      path: /
+      port: http
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
## Summary

Adds a Helm chart to enable deploying `allure-docker-service` on Kubernetes clusters.

## Changes

- Added `charts/allure-docker-service/` with a fully functional Helm chart including:
  - Deployments for both the API and UI components
  - Services, Ingress, and HTTPRoute templates
  - PersistentVolumeClaim for report storage
  - Secrets management template
  - ServiceAccount support
  - `_helpers.tpl` with reusable template definitions
  - `values.yaml` with sensible defaults
  - `NOTES.txt` with post-install usage instructions

## Motivation

This makes it easier to deploy allure-docker-service in Kubernetes environments without having to manually craft manifests, and enables configuration via Helm values.