### PR TITLE
Add Model Context Protocol (MCP) server for Allure Docker Service

### DIFF
--- a/.github/workflows/allure-mcp.yml
+++ b/.github/workflows/allure-mcp.yml
@@ -1,0 +1,82 @@
+name: Allure MCP Docker
+
+# Builds the MCP server image (allure-docker-mcp/) and publishes it to Docker Hub.
+#
+#   - Pull requests touching the package -> build only (validation), never push.
+#   - Push to master/main (e.g. when this package is merged) -> publish :edge.
+#   - Release tags v*                                        -> publish <version> + :latest.
+#
+# Publishing reuses the repo's existing Docker Hub credentials and is guarded to
+# the upstream repository, so it never runs from a fork (which has no secrets).
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - "allure-docker-mcp/**"
+      - ".github/workflows/allure-mcp.yml"
+
+env:
+  MCP_DOCKER_IMAGE: frankescobar/allure-docker-mcp
+
+jobs:
+  mcp-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pulling code
+        uses: actions/checkout@v4
+
+      - name: Resolve tags, platforms and whether to publish
+        id: meta
+        run: |
+          PUSH=false
+          if [[ "${{ github.event_name }}" != "pull_request" && "${{ github.repository }}" == "fescobar/allure-docker-service" ]]; then
+            PUSH=true
+          fi
+
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+            TAGS="${MCP_DOCKER_IMAGE}:${VERSION},${MCP_DOCKER_IMAGE}:latest"
+            PLATFORMS="linux/amd64,linux/arm64"
+          else
+            TAGS="${MCP_DOCKER_IMAGE}:edge"
+            # amd64 only off the default branch / PRs to keep these builds fast.
+            PLATFORMS="linux/amd64"
+          fi
+
+          {
+            echo "push=${PUSH}"
+            echo "tags=${TAGS}"
+            echo "platforms=${PLATFORMS}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved push=${PUSH} platforms=${PLATFORMS} tags=${TAGS}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub login
+        if: steps.meta.outputs.push == 'true'
+        env:
+          DOCKER_HUB_USER: ${{ vars.DOCKER_HUB_USER }}
+          DOCKER_HUB_PASS: ${{ secrets.DOCKER_HUB_PASS }}
+        run: echo "${DOCKER_HUB_PASS}" | docker login -u "${DOCKER_HUB_USER}" --password-stdin
+
+      - name: Build (and publish on upstream push/tag)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./allure-docker-mcp
+          file: ./allure-docker-mcp/Dockerfile
+          platforms: ${{ steps.meta.outputs.platforms }}
+          push: ${{ steps.meta.outputs.push == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          provenance: false

--- a/allure-docker-mcp/.dockerignore
+++ b/allure-docker-mcp/.dockerignore
@@ -1,0 +1,9 @@
+**/__pycache__/
+**/*.pyc
+.pytest_cache/
+.env
+tests/
+*.egg-info/
+build/
+dist/
+.venv/

--- a/allure-docker-mcp/.env.example
+++ b/allure-docker-mcp/.env.example
@@ -1,0 +1,23 @@
+# Base URL of the running allure-docker-service instance.
+# If exposed under a path prefix, include it, e.g. http://host:5050/allure-docker-service
+ALLURE_ENDPOINT=http://localhost:5050
+
+# Credentials — only needed when the service runs with SECURITY_ENABLED=1.
+# ALLURE_USERNAME=admin
+# ALLURE_PASSWORD=some-password
+
+# Set to false to skip TLS certificate verification (self-signed certs).
+ALLURE_SSL_VERIFY=true
+
+# Per-request timeout in seconds.
+ALLURE_TIMEOUT=30
+
+# Directory the export tools may write into (exports are confined here).
+ALLURE_OUTPUT_DIR=allure-exports
+
+# Transport for the MCP server: "stdio" (default), "streamable-http", or "sse".
+ALLURE_MCP_TRANSPORT=stdio
+
+# Bind address/port for the HTTP transports (streamable-http / sse).
+# FASTMCP_HOST=127.0.0.1
+# FASTMCP_PORT=8000

--- a/allure-docker-mcp/.gitignore
+++ b/allure-docker-mcp/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+.pytest_cache/
+.venv/
+.env

--- a/allure-docker-mcp/Dockerfile
+++ b/allure-docker-mcp/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.title="allure-docker-mcp" \
+      org.opencontainers.image.description="MCP server for Allure Docker Service" \
+      org.opencontainers.image.source="https://github.com/fescobar/allure-docker-service"
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    ALLURE_ENDPOINT=http://localhost:5050 \
+    ALLURE_MCP_TRANSPORT=streamable-http \
+    FASTMCP_HOST=0.0.0.0 \
+    FASTMCP_PORT=8000
+
+WORKDIR /app
+
+COPY pyproject.toml requirements.txt README.md ./
+COPY allure_docker_mcp ./allure_docker_mcp
+
+RUN pip install --no-cache-dir .
+
+# Run as an unprivileged user.
+RUN useradd --create-home --uid 1000 appuser
+USER appuser
+
+EXPOSE 8000
+
+ENTRYPOINT ["allure-docker-mcp"]

--- a/allure-docker-mcp/README.md
+++ b/allure-docker-mcp/README.md
@@ -106,6 +106,18 @@ allure-docker-mcp
 
 ### Docker
 
+A prebuilt image is published to Docker Hub as
+[`frankescobar/allure-docker-mcp`](https://hub.docker.com/r/frankescobar/allure-docker-mcp)
+(`:latest` for tagged releases, `:edge` from `master`):
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e ALLURE_ENDPOINT=http://host.docker.internal:5050 \
+  frankescobar/allure-docker-mcp
+```
+
+Or build it locally:
+
 ```bash
 docker build -t allure-docker-mcp ./allure-docker-mcp
 docker run --rm -p 8000:8000 \

--- a/allure-docker-mcp/README.md
+++ b/allure-docker-mcp/README.md
@@ -1,0 +1,156 @@
+# Allure Docker Service — MCP Server
+
+A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that
+exposes a running [`allure-docker-service`](https://github.com/fescobar/allure-docker-service)
+instance as tools an LLM agent can call. Manage projects, send test results,
+generate and export [Allure](https://allurereport.org/) reports, and inspect
+service state — all through natural-language driven tool calls in MCP-compatible
+clients such as Claude Desktop, Claude Code, or any MCP host.
+
+This server is a **client** of the Allure Docker Service REST API — it does not
+replace it. Run `allure-docker-service` as usual, then point this MCP server at it.
+
+## Features
+
+The server wraps the full REST API. Each tool maps to one endpoint:
+
+| Tool | Endpoint | Description |
+| --- | --- | --- |
+| `get_version` | `GET /version` | Allure version used by the service |
+| `get_config` | `GET /config` | Service configuration |
+| `list_projects` | `GET /projects` | List all projects |
+| `get_project` | `GET /projects/{id}` | Get a project and its reports |
+| `search_projects` | `GET /projects/search` | Search projects by id |
+| `create_project` | `POST /projects` | Create a new project |
+| `delete_project` | `DELETE /projects/{id}` | Delete a project |
+| `send_results` | `POST /send-results` | Send base64-encoded result files |
+| `send_results_from_directory` | `POST /send-results` | Encode + send a local results directory |
+| `generate_report` | `GET /generate-report` | Generate a report from current results |
+| `get_latest_report` | `GET /latest-report` | URL of the latest report |
+| `clean_results` | `GET /clean-results` | Delete pending results |
+| `clean_history` | `GET /clean-history` | Delete history & trends |
+| `export_report` | `GET /report/export` | Export full report as a ZIP to disk |
+| `export_emailable_report` | `GET /emailable-report/export` | Export emailable HTML to disk |
+| `render_emailable_report` | `GET /emailable-report/render` | Return emailable HTML as a string |
+
+It also transparently handles the service's optional **security mode**
+(`SECURITY_ENABLED=1`): it logs in, persists the JWT cookies, and echoes the
+`csrf_access_token` cookie in the `X-CSRF-TOKEN` header on mutating requests.
+
+## Installation
+
+Requires Python 3.10+.
+
+```bash
+cd allure-docker-mcp
+pip install .
+# or, for development (adds pytest + respx):
+pip install -e ".[dev]"
+```
+
+This installs an `allure-docker-mcp` console script.
+
+## Configuration
+
+All configuration is via environment variables (see `.env.example`):
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ALLURE_ENDPOINT` | `http://localhost:5050` | Base URL of the **API**. Include any path prefix — use the `full_allure_docker_api_url` value reported by `GET /config`, not the web UI root. |
+| `ALLURE_USERNAME` | — | Username (only for security mode) |
+| `ALLURE_PASSWORD` | — | Password (only for security mode) |
+| `ALLURE_SSL_VERIFY` | `true` | Set `false` to skip TLS verification |
+| `ALLURE_TIMEOUT` | `30` | Per-request timeout (seconds) |
+| `ALLURE_OUTPUT_DIR` | `allure-exports` | Directory the export tools may write into. Exports are confined here; paths that escape it are rejected. |
+| `ALLURE_MCP_TRANSPORT` | `stdio` | `stdio`, `streamable-http`, or `sse` |
+| `FASTMCP_HOST` | `127.0.0.1` | Bind address for the HTTP transports |
+| `FASTMCP_PORT` | `8000` | Bind port for the HTTP transports |
+
+> **Tip:** point `ALLURE_ENDPOINT` at the API base, not the UI. Many deployments
+> serve a web UI at the root and the API under a prefix (e.g. `…/allure-api/allure-docker-service`).
+> If a tool returns an "Expected a JSON response … not the web UI" error, fetch
+> `GET /config` and use its `full_allure_docker_api_url`.
+
+## Usage
+
+### Claude Desktop / Claude Code (stdio)
+
+Add to your MCP client config (e.g. `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "allure": {
+      "command": "allure-docker-mcp",
+      "env": {
+        "ALLURE_ENDPOINT": "http://localhost:5050"
+      }
+    }
+  }
+}
+```
+
+Or run the module directly without installing the script:
+
+```bash
+ALLURE_ENDPOINT=http://localhost:5050 python -m allure_docker_mcp
+```
+
+### Streamable HTTP
+
+```bash
+ALLURE_MCP_TRANSPORT=streamable-http \
+FASTMCP_HOST=0.0.0.0 FASTMCP_PORT=8000 \
+allure-docker-mcp
+```
+
+### Docker
+
+```bash
+docker build -t allure-docker-mcp ./allure-docker-mcp
+docker run --rm -p 8000:8000 \
+  -e ALLURE_ENDPOINT=http://host.docker.internal:5050 \
+  allure-docker-mcp
+```
+
+The image defaults to the `streamable-http` transport on port `8000`.
+
+### Security note for the HTTP transports
+
+The `streamable-http` and `sse` transports are **unauthenticated** — anyone who
+can reach the port can invoke every tool, including the file-touching ones
+(`send_results_from_directory` reads local files; `export_*` write into
+`ALLURE_OUTPUT_DIR`). Bind to `127.0.0.1` for local use, and only expose the
+port behind an authenticating reverse proxy or a network policy. For untrusted
+or desktop use, prefer the `stdio` transport, which has no network surface.
+
+## Scope
+
+Every REST endpoint has a corresponding tool **except** `GET /projects/{id}/reports/{path}`,
+which streams individual report artifacts (HTML/JSON files). Raw artifact
+retrieval is intentionally out of scope — use `get_project` / `get_latest_report`
+to obtain report URLs, or `export_report` to download a full report archive.
+
+## Example interactions
+
+> "Create a project called `regression-suite`, then send the results from
+> `./allure-results` and generate a report."
+
+The agent calls `create_project("regression-suite")`,
+`send_results_from_directory("./allure-results", project_id="regression-suite")`,
+then `generate_report(project_id="regression-suite")` and reports the
+`get_latest_report` URL.
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest
+```
+
+The tests mock the REST API with [`respx`](https://lundberg.github.io/respx/) — no
+running `allure-docker-service` instance is required.
+
+## License
+
+Apache-2.0, same as the parent project.

--- a/allure-docker-mcp/allure_docker_mcp/__init__.py
+++ b/allure-docker-mcp/allure_docker_mcp/__init__.py
@@ -1,0 +1,8 @@
+"""MCP (Model Context Protocol) server for Allure Docker Service."""
+
+from .client import AllureAPIError, AllureClient
+from .server import build_client, main, mcp
+
+__version__ = "1.0.0"
+
+__all__ = ["AllureAPIError", "AllureClient", "build_client", "main", "mcp", "__version__"]

--- a/allure-docker-mcp/allure_docker_mcp/__main__.py
+++ b/allure-docker-mcp/allure_docker_mcp/__main__.py
@@ -1,0 +1,6 @@
+"""Allow ``python -m allure_docker_mcp`` to start the server."""
+
+from .server import main
+
+if __name__ == "__main__":
+    main()

--- a/allure-docker-mcp/allure_docker_mcp/client.py
+++ b/allure-docker-mcp/allure_docker_mcp/client.py
@@ -1,0 +1,219 @@
+"""HTTP client for the Allure Docker Service REST API.
+
+Wraps the REST API exposed by ``allure-docker-api`` (Flask). When the service is
+started with ``SECURITY_ENABLED=1`` it protects every endpoint with a JWT stored
+in cookies and enforces CSRF protection on mutating requests
+(``JWT_COOKIE_CSRF_PROTECT=True``). This client transparently handles that flow:
+
+* ``POST /login`` exchanges username/password for the ``access_token_cookie`` and
+  ``csrf_access_token`` cookies, which are persisted in a single ``httpx.Client``
+  cookie jar.
+* For mutating methods (POST/PUT/PATCH/DELETE) the value of the
+  ``csrf_access_token`` cookie is echoed back in the ``X-CSRF-TOKEN`` header,
+  exactly as Flask-JWT-Extended expects.
+* A single retry is performed on ``401`` responses (expired access token) by
+  re-authenticating before the request is replayed.
+
+When the service runs without security (the default), no login is attempted and
+no CSRF header is sent.
+"""
+
+from __future__ import annotations
+
+import base64
+import threading
+from typing import Any, Optional
+
+import httpx
+
+# Methods Flask-JWT-Extended subjects to CSRF protection by default
+# (JWT_CSRF_METHODS). GET/HEAD/OPTIONS are exempt.
+_CSRF_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# Cookie set by the service on login; its value must be echoed in X-CSRF-TOKEN.
+_CSRF_COOKIE_NAME = "csrf_access_token"
+
+
+class AllureAPIError(RuntimeError):
+    """Raised when the Allure Docker Service API returns an error response.
+
+    The service returns a JSON body shaped like ``{"meta_data": {"message": ...}}``
+    for errors; that message is surfaced here so the caller (and an LLM driving
+    the MCP tool) gets an actionable explanation rather than a bare status code.
+    """
+
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"Allure API error {status_code}: {message}")
+
+
+class AllureClient:
+    """Thin, synchronous wrapper around the Allure Docker Service REST API."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        ssl_verify: bool = True,
+        timeout: float = 30.0,
+    ) -> None:
+        if not endpoint:
+            raise ValueError("endpoint is required")
+        self.endpoint = endpoint.rstrip("/")
+        self.username = username or None
+        self.password = password or None
+        self._client = httpx.Client(
+            verify=ssl_verify,
+            timeout=timeout,
+            follow_redirects=True,
+        )
+        self._logged_in = False
+        # Tools run in worker threads (see server._tool), so guard the lazy
+        # login / re-login against concurrent callers sharing this client.
+        self._auth_lock = threading.Lock()
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "AllureClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- auth --------------------------------------------------------------
+
+    @property
+    def security_enabled(self) -> bool:
+        """True when credentials were supplied, i.e. the target uses security mode."""
+        return bool(self.username and self.password)
+
+    def login(self) -> None:
+        """Authenticate and persist the JWT/CSRF cookies in the client cookie jar."""
+        if not self.security_enabled:
+            return
+        resp = self._client.post(
+            self._url("/login"),
+            json={"username": self.username, "password": self.password},
+        )
+        self._raise_for_error(resp)
+        self._logged_in = True
+
+    def _ensure_auth(self) -> None:
+        if not self.security_enabled or self._logged_in:
+            return
+        with self._auth_lock:
+            if not self._logged_in:
+                self.login()
+
+    def _relogin(self) -> None:
+        """Force a fresh login (e.g. after a 401), serialized across threads."""
+        with self._auth_lock:
+            self._logged_in = False
+            self.login()
+
+    def _csrf_header(self) -> dict[str, str]:
+        token = self._client.cookies.get(_CSRF_COOKIE_NAME)
+        return {"X-CSRF-TOKEN": token} if token else {}
+
+    # -- request plumbing --------------------------------------------------
+
+    def _url(self, path: str) -> str:
+        return f"{self.endpoint}/{path.lstrip('/')}"
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json: Optional[Any] = None,
+        follow_redirects: bool = True,
+    ) -> httpx.Response:
+        """Send a request, applying auth + CSRF and retrying once on 401.
+
+        Set ``follow_redirects=False`` for endpoints (e.g. ``/latest-report``)
+        whose useful payload is the ``Location`` header of a 3xx response rather
+        than the redirected page body.
+        """
+        self._ensure_auth()
+        url = self._url(path)
+        params = {k: v for k, v in (params or {}).items() if v is not None}
+        needs_csrf = method.upper() in _CSRF_METHODS
+
+        # At most two attempts: the second only happens on a 401 in security mode,
+        # where the access token has likely expired and we re-authenticate.
+        for attempt in range(2):
+            resp = self._client.request(
+                method,
+                url,
+                params=params,
+                json=json,
+                headers=self._csrf_header() if needs_csrf else {},
+                follow_redirects=follow_redirects,
+            )
+            if resp.status_code != 401 or not self.security_enabled or attempt == 1:
+                break
+            self._relogin()
+
+        self._raise_for_error(resp)
+        return resp
+
+    def request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json: Optional[Any] = None,
+    ) -> Any:
+        """Send a request and return the parsed JSON body.
+
+        Raises :class:`AllureAPIError` if the body is not JSON. The most common
+        cause is ``ALLURE_ENDPOINT`` pointing at the web UI instead of the API
+        base URL — the UI answers most paths with its SPA ``index.html``, which
+        would otherwise be returned silently as opaque text.
+        """
+        resp = self.request(method, path, params=params, json=json)
+        try:
+            return resp.json()
+        except ValueError:
+            ctype = resp.headers.get("content-type", "") or "a non-JSON body"
+            snippet = resp.text[:120].replace("\n", " ").strip()
+            raise AllureAPIError(
+                resp.status_code,
+                f"Expected a JSON response from {path!r} but received {ctype} "
+                f"(starts with: {snippet!r}). Verify ALLURE_ENDPOINT points at the "
+                "Allure Docker Service API base URL (the 'full_allure_docker_api_url' "
+                "value returned by GET /config), not the web UI.",
+            )
+
+    # -- error / parsing helpers ------------------------------------------
+
+    @staticmethod
+    def _extract_message(resp: httpx.Response) -> str:
+        try:
+            body = resp.json()
+        except ValueError:
+            text = resp.text.strip()
+            return text or resp.reason_phrase or "unknown error"
+        if isinstance(body, dict):
+            meta = body.get("meta_data")
+            if isinstance(meta, dict) and meta.get("message"):
+                return str(meta["message"])
+        return resp.reason_phrase or "unknown error"
+
+    def _raise_for_error(self, resp: httpx.Response) -> None:
+        if resp.status_code >= 400:
+            raise AllureAPIError(resp.status_code, self._extract_message(resp))
+
+    # -- base64 helper -----------------------------------------------------
+
+    @staticmethod
+    def encode_file(content: bytes) -> str:
+        """Base64-encode raw file bytes for the ``content_base64`` field."""
+        return base64.b64encode(content).decode("ascii")

--- a/allure-docker-mcp/allure_docker_mcp/server.py
+++ b/allure-docker-mcp/allure_docker_mcp/server.py
@@ -1,0 +1,437 @@
+"""MCP server exposing the Allure Docker Service REST API as tools.
+
+The server wraps a running `allure-docker-service` instance so that an LLM agent
+(via the Model Context Protocol) can manage projects, send test results, generate
+and export Allure reports, and inspect service state.
+
+Configuration is read from environment variables:
+
+* ``ALLURE_ENDPOINT``    Base URL of the service. Default ``http://localhost:5050``.
+                         If the service is exposed under a path prefix, include it,
+                         e.g. ``http://host:5050/allure-docker-service`` (the
+                         ``full_allure_docker_api_url`` value from ``GET /config``).
+* ``ALLURE_USERNAME``    Username for security mode (optional).
+* ``ALLURE_PASSWORD``    Password for security mode (optional).
+* ``ALLURE_SSL_VERIFY``  ``false`` to disable TLS verification. Default ``true``.
+* ``ALLURE_TIMEOUT``     Per-request timeout in seconds. Default ``30``.
+* ``ALLURE_OUTPUT_DIR``  Directory the export tools may write into. Default
+                         ``allure-exports`` (relative to the working directory).
+                         Exports are confined to this directory.
+
+Run with the ``stdio`` (default), ``streamable-http``, or ``sse`` transport,
+selected via ``ALLURE_MCP_TRANSPORT`` — see ``main`` / the README.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import anyio
+from mcp.server.fastmcp import FastMCP
+
+from .client import AllureAPIError, AllureClient
+
+__all__ = ["mcp", "build_client", "main"]
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def build_client() -> AllureClient:
+    """Construct an :class:`AllureClient` from environment configuration."""
+    timeout_raw = os.environ.get("ALLURE_TIMEOUT", "30")
+    try:
+        timeout = float(timeout_raw)
+    except ValueError:
+        timeout = 30.0
+    return AllureClient(
+        endpoint=os.environ.get("ALLURE_ENDPOINT", "http://localhost:5050"),
+        username=os.environ.get("ALLURE_USERNAME"),
+        password=os.environ.get("ALLURE_PASSWORD"),
+        ssl_verify=_env_bool("ALLURE_SSL_VERIFY", True),
+        timeout=timeout,
+    )
+
+
+def _output_root() -> Path:
+    """Directory the export tools are confined to (``ALLURE_OUTPUT_DIR``)."""
+    return Path(os.environ.get("ALLURE_OUTPUT_DIR", "allure-exports")).expanduser().resolve()
+
+
+mcp = FastMCP(
+    "Allure Docker Service",
+    instructions=(
+        "Tools for managing Allure test reports through a running "
+        "allure-docker-service instance: create/list/delete projects, send "
+        "results, generate and export reports, and inspect service state. "
+        "When a tool takes 'project_id' and you omit it, the service uses the "
+        "'default' project."
+    ),
+)
+
+# A single long-lived client so the auth/CSRF cookie jar persists across calls.
+_client: Optional[AllureClient] = None
+
+
+def _get_client() -> AllureClient:
+    global _client
+    if _client is None:
+        _client = build_client()
+    return _client
+
+
+def _tool(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Register ``fn`` as an MCP tool, offloading its (blocking) body to a thread.
+
+    FastMCP calls a synchronous tool inline on the asyncio event loop, so the
+    blocking httpx/disk work in these tools would stall every other request
+    under the ``streamable-http``/``sse`` transports. Wrapping the body in
+    ``anyio.to_thread.run_sync`` keeps the loop responsive; ``functools.wraps``
+    preserves the signature/docstring FastMCP introspects to build the schema.
+    """
+
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return await anyio.to_thread.run_sync(functools.partial(fn, *args, **kwargs))
+
+    return mcp.tool()(wrapper)
+
+
+# --------------------------------------------------------------------------
+# Service info
+# --------------------------------------------------------------------------
+
+
+@_tool
+def get_version() -> dict[str, Any]:
+    """Return the Allure version used by the service."""
+    return _get_client().request_json("GET", "/version")
+
+
+@_tool
+def get_config() -> dict[str, Any]:
+    """Return the service configuration (check timing, security mode, etc.)."""
+    return _get_client().request_json("GET", "/config")
+
+
+# --------------------------------------------------------------------------
+# Projects
+# --------------------------------------------------------------------------
+
+
+@_tool
+def list_projects() -> dict[str, Any]:
+    """List all existing projects and the URIs to inspect each one."""
+    return _get_client().request_json("GET", "/projects")
+
+
+@_tool
+def get_project(project_id: str) -> dict[str, Any]:
+    """Get a single project, including the list of available reports.
+
+    Args:
+        project_id: Identifier of the project to fetch.
+    """
+    return _get_client().request_json("GET", f"/projects/{project_id}")
+
+
+@_tool
+def search_projects(query: str) -> dict[str, Any]:
+    """Search for projects whose id matches the given query string.
+
+    Args:
+        query: Substring to match against project ids.
+    """
+    return _get_client().request_json("GET", "/projects/search", params={"id": query})
+
+
+@_tool
+def create_project(project_id: str) -> dict[str, Any]:
+    """Create a new project.
+
+    Args:
+        project_id: New project id. Must be lowercase alphanumeric characters or
+            hyphens (e.g. ``my-project-id``), max 100 chars, and not ``default``.
+    """
+    return _get_client().request_json("POST", "/projects", json={"id": project_id})
+
+
+@_tool
+def delete_project(project_id: str) -> dict[str, Any]:
+    """Delete an existing project and all of its results/reports.
+
+    Args:
+        project_id: Identifier of the project to delete. The ``default`` project
+            cannot be removed. Requires admin privileges in security mode.
+    """
+    return _get_client().request_json("DELETE", f"/projects/{project_id}")
+
+
+# --------------------------------------------------------------------------
+# Results & reports
+# --------------------------------------------------------------------------
+
+
+def _send_results(
+    results: list[dict[str, str]],
+    project_id: Optional[str],
+    force_project_creation: bool,
+) -> dict[str, Any]:
+    """Shared POST /send-results call used by both send_results tools."""
+    params = {
+        "project_id": project_id,
+        "force_project_creation": "true" if force_project_creation else None,
+    }
+    return _get_client().request_json(
+        "POST", "/send-results", params=params, json={"results": results}
+    )
+
+
+@_tool
+def send_results(
+    results: list[dict[str, str]],
+    project_id: Optional[str] = None,
+    force_project_creation: bool = False,
+) -> dict[str, Any]:
+    """Send Allure result files (already base64-encoded) to a project.
+
+    Args:
+        results: List of result files. Each item must be
+            ``{"file_name": "<name>", "content_base64": "<base64 content>"}``.
+            File names must be unique within the request.
+        project_id: Target project. Omit to use the ``default`` project.
+        force_project_creation: When True, create the project if it does not exist.
+
+    Returns:
+        On success, the service summary of processed files (omitted when the
+        service runs with ``API_RESPONSE_LESS_VERBOSE=1``). A file that fails to
+        process makes the service return an error instead of a partial-success body.
+    """
+    return _send_results(results, project_id, force_project_creation)
+
+
+@_tool
+def send_results_from_directory(
+    directory: str,
+    project_id: Optional[str] = None,
+    force_project_creation: bool = False,
+) -> dict[str, Any]:
+    """Read every file in a local directory, base64-encode it, and send as results.
+
+    A convenience wrapper over :func:`send_results` for the common case of having
+    an ``allure-results`` directory on disk. Every top-level regular file is
+    uploaded to ``ALLURE_ENDPOINT``; symlinks are skipped so the tool cannot be
+    pointed at a symlink that resolves to sensitive files outside the directory.
+
+    Args:
+        directory: Path to a local directory containing Allure result files.
+        project_id: Target project. Omit to use the ``default`` project.
+        force_project_creation: When True, create the project if it does not exist.
+    """
+    base = Path(directory).expanduser()
+    if not base.is_dir():
+        raise ValueError(f"Not a directory: {directory}")
+
+    results = [
+        {
+            "file_name": entry.name,
+            "content_base64": AllureClient.encode_file(entry.read_bytes()),
+        }
+        for entry in sorted(base.iterdir())
+        if entry.is_file() and not entry.is_symlink()
+    ]
+    if not results:
+        raise ValueError(f"No regular files found in directory: {directory}")
+
+    return _send_results(results, project_id, force_project_creation)
+
+
+@_tool
+def generate_report(
+    project_id: Optional[str] = None,
+    execution_name: Optional[str] = None,
+    execution_from: Optional[str] = None,
+    execution_type: Optional[str] = None,
+) -> dict[str, Any]:
+    """Generate a new Allure report from the project's current results.
+
+    Args:
+        project_id: Target project. Omit to use the ``default`` project.
+        execution_name: Label shown for this execution in the report (e.g. a CI job name).
+        execution_from: Link back to the source of the execution (e.g. a build URL).
+        execution_type: Type of the execution source (e.g. ``github``, ``jenkins``).
+    """
+    params = {
+        "project_id": project_id,
+        "execution_name": execution_name,
+        "execution_from": execution_from,
+        "execution_type": execution_type,
+    }
+    return _get_client().request_json("GET", "/generate-report", params=params)
+
+
+@_tool
+def get_latest_report(project_id: Optional[str] = None) -> dict[str, Any]:
+    """Get the URL of the latest generated report for a project.
+
+    The service answers this endpoint with a redirect to the report's
+    ``index.html``; this tool returns that target URL instead of following it.
+
+    Args:
+        project_id: Target project. Omit to use the ``default`` project.
+
+    Returns:
+        ``{"report_url": "<absolute url to the latest report>"}``.
+    """
+    resp = _get_client().request(
+        "GET",
+        "/latest-report",
+        params={"project_id": project_id},
+        follow_redirects=False,
+    )
+    # The endpoint answers with a 302 whose Location is the report; if there is
+    # no redirect (older/edge cases) fall back to the final URL we landed on.
+    location = resp.headers.get("location")
+    report_url = str(resp.request.url.join(location)) if location else str(resp.url)
+    return {"report_url": report_url}
+
+
+@_tool
+def clean_results(project_id: Optional[str] = None) -> dict[str, Any]:
+    """Delete all pending results for a project (does not touch generated reports).
+
+    Args:
+        project_id: Target project. Omit to use the ``default`` project.
+    """
+    return _get_client().request_json(
+        "GET", "/clean-results", params={"project_id": project_id}
+    )
+
+
+@_tool
+def clean_history(project_id: Optional[str] = None) -> dict[str, Any]:
+    """Delete the history and trends of a project's reports.
+
+    Args:
+        project_id: Target project. Omit to use the ``default`` project.
+    """
+    return _get_client().request_json(
+        "GET", "/clean-history", params={"project_id": project_id}
+    )
+
+
+# --------------------------------------------------------------------------
+# Exports (file-returning endpoints saved to local disk)
+# --------------------------------------------------------------------------
+
+
+def _resolve_output(output_path: str) -> Path:
+    """Resolve ``output_path`` inside the export root, rejecting any escape.
+
+    ``output_path`` is interpreted relative to ``ALLURE_OUTPUT_DIR``. Absolute
+    paths and ``..`` segments that would land outside that root are refused, so
+    a tool call cannot overwrite arbitrary files on the host.
+    """
+    root = _output_root()
+    candidate = (root / output_path).resolve()
+    if not candidate.is_relative_to(root):
+        raise ValueError(
+            f"Refusing to write outside the export root {root}: {output_path!r} "
+            "escapes it. Pass a path inside the root, or set ALLURE_OUTPUT_DIR."
+        )
+    return candidate
+
+
+def _download_to(output_path: str, api_path: str, project_id: Optional[str]) -> dict[str, Any]:
+    out = _resolve_output(output_path)
+    resp = _get_client().request("GET", api_path, params={"project_id": project_id})
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(resp.content)
+    return {
+        "saved_to": str(out),
+        "bytes": len(resp.content),
+        "content_type": resp.headers.get("content-type", "application/octet-stream"),
+    }
+
+
+@_tool
+def export_report(output_path: str, project_id: Optional[str] = None) -> dict[str, Any]:
+    """Export the full Allure report as a ZIP archive saved to a local path.
+
+    Args:
+        output_path: Destination for the ``.zip`` archive, relative to
+            ``ALLURE_OUTPUT_DIR`` (default ``allure-exports``). Paths that escape
+            that directory are rejected.
+        project_id: Target project. Omit to use the ``default`` project.
+
+    Returns:
+        Where the file was saved, its size in bytes, and the content type.
+    """
+    return _download_to(output_path, "/report/export", project_id)
+
+
+@_tool
+def export_emailable_report(
+    output_path: str, project_id: Optional[str] = None
+) -> dict[str, Any]:
+    """Export the single-file emailable HTML report to a local path.
+
+    Args:
+        output_path: Destination for the ``.html`` report, relative to
+            ``ALLURE_OUTPUT_DIR`` (default ``allure-exports``). Paths that escape
+            that directory are rejected.
+        project_id: Target project. Omit to use the ``default`` project.
+    """
+    return _download_to(output_path, "/emailable-report/export", project_id)
+
+
+@_tool
+def render_emailable_report(project_id: Optional[str] = None) -> str:
+    """Render the emailable HTML report and return it as a string.
+
+    Args:
+        project_id: Target project. Omit to use the ``default`` project.
+
+    Returns:
+        The rendered HTML document.
+    """
+    resp = _get_client().request(
+        "GET", "/emailable-report/render", params={"project_id": project_id}
+    )
+    return resp.text
+
+
+def _configure_transport() -> str:
+    """Resolve the transport and, for HTTP transports, apply the bind settings.
+
+    FastMCP passes its own host/port defaults into ``Settings``, which take
+    precedence over the ``FASTMCP_*`` env vars (pydantic-settings ranks explicit
+    init kwargs above the environment). So the env vars are otherwise ignored;
+    apply them explicitly here, before ``run`` reads ``mcp.settings``, so the HTTP
+    transports actually bind where the operator asked.
+    """
+    transport = os.environ.get("ALLURE_MCP_TRANSPORT", "stdio").strip().lower()
+    if transport != "stdio":
+        host = os.environ.get("FASTMCP_HOST")
+        port = os.environ.get("FASTMCP_PORT")
+        if host:
+            mcp.settings.host = host
+        if port:
+            mcp.settings.port = int(port)
+    return transport
+
+
+def main() -> None:
+    """Entry point: run the MCP server over the configured transport."""
+    mcp.run(transport=_configure_transport())  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    main()

--- a/allure-docker-mcp/pyproject.toml
+++ b/allure-docker-mcp/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "allure-docker-mcp"
+version = "1.0.0"
+description = "Model Context Protocol (MCP) server for Allure Docker Service"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+keywords = ["allure", "mcp", "model-context-protocol", "testing", "reporting", "llm"]
+authors = [{ name = "allure-docker-service contributors" }]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "mcp[cli]>=1.2.0",
+    "httpx>=0.27.0",
+    "anyio>=4.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "respx>=0.21.0",
+]
+
+[project.scripts]
+allure-docker-mcp = "allure_docker_mcp.server:main"
+
+[project.urls]
+Homepage = "https://github.com/fescobar/allure-docker-service"
+Repository = "https://github.com/fescobar/allure-docker-service"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["allure_docker_mcp*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/allure-docker-mcp/requirements.txt
+++ b/allure-docker-mcp/requirements.txt
@@ -1,0 +1,5 @@
+# Runtime dependencies for the Allure Docker Service MCP server.
+# For development/test extras (pytest, respx) install: pip install -e ".[dev]"
+mcp[cli]>=1.2.0
+httpx>=0.27.0
+anyio>=4.0.0

--- a/allure-docker-mcp/tests/test_client.py
+++ b/allure-docker-mcp/tests/test_client.py
@@ -1,0 +1,127 @@
+"""Tests for the AllureClient HTTP/auth/CSRF behaviour."""
+
+import base64
+
+import httpx
+import pytest
+import respx
+
+from allure_docker_mcp.client import AllureAPIError, AllureClient
+
+ENDPOINT = "http://allure.test:5050"
+
+
+def test_url_joins_without_double_slash():
+    client = AllureClient(endpoint=ENDPOINT + "/")
+    assert client._url("/version") == f"{ENDPOINT}/version"
+    assert client._url("version") == f"{ENDPOINT}/version"
+    client.close()
+
+
+@respx.mock
+def test_get_request_returns_json():
+    route = respx.get(f"{ENDPOINT}/version").mock(
+        return_value=httpx.Response(200, json={"data": {"version": "2.27.0"}})
+    )
+    with AllureClient(endpoint=ENDPOINT) as client:
+        body = client.request_json("GET", "/version")
+    assert route.called
+    assert body["data"]["version"] == "2.27.0"
+
+
+@respx.mock
+def test_get_does_not_send_csrf_header():
+    route = respx.get(f"{ENDPOINT}/projects").mock(
+        return_value=httpx.Response(200, json={"data": {"projects": {}}})
+    )
+    with AllureClient(endpoint=ENDPOINT) as client:
+        # Pretend a csrf cookie exists; GET must still not send the header.
+        client._client.cookies.set("csrf_access_token", "tok", domain="allure.test")
+        client.request_json("GET", "/projects")
+    assert "X-CSRF-TOKEN" not in route.calls.last.request.headers
+
+
+@respx.mock
+def test_error_message_extracted_from_meta_data():
+    respx.post(f"{ENDPOINT}/projects").mock(
+        return_value=httpx.Response(
+            400, json={"meta_data": {"message": "project_id 'x' is existent"}}
+        )
+    )
+    with AllureClient(endpoint=ENDPOINT) as client:
+        with pytest.raises(AllureAPIError) as exc:
+            client.request_json("POST", "/projects", json={"id": "x"})
+    assert exc.value.status_code == 400
+    assert "is existent" in exc.value.message
+
+
+@respx.mock
+def test_security_mode_logs_in_and_sends_csrf_on_post():
+    login = respx.post(f"{ENDPOINT}/login").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {}},
+            headers=[
+                ("set-cookie", "access_token_cookie=jwt; Path=/"),
+                ("set-cookie", "csrf_access_token=csrf123; Path=/"),
+            ],
+        )
+    )
+    send = respx.post(f"{ENDPOINT}/send-results").mock(
+        return_value=httpx.Response(200, json={"meta_data": {"message": "ok"}})
+    )
+    with AllureClient(endpoint=ENDPOINT, username="admin", password="pw") as client:
+        assert client.security_enabled is True
+        client.request_json(
+            "POST",
+            "/send-results",
+            json={"results": [{"file_name": "a.json", "content_base64": "e30="}]},
+        )
+
+    assert login.called
+    assert send.called
+    assert send.calls.last.request.headers.get("X-CSRF-TOKEN") == "csrf123"
+
+
+@respx.mock
+def test_401_triggers_reauth_and_retry():
+    respx.post(f"{ENDPOINT}/login").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {}},
+            headers=[("set-cookie", "csrf_access_token=fresh; Path=/")],
+        )
+    )
+    route = respx.get(f"{ENDPOINT}/config").mock(
+        side_effect=[
+            httpx.Response(401, json={"meta_data": {"message": "expired"}}),
+            httpx.Response(200, json={"data": {"version": "2.27.0"}}),
+        ]
+    )
+    with AllureClient(endpoint=ENDPOINT, username="admin", password="pw") as client:
+        body = client.request_json("GET", "/config")
+    assert route.call_count == 2
+    assert body["data"]["version"] == "2.27.0"
+
+
+@respx.mock
+def test_html_response_raises_helpful_error():
+    # Mis-pointed endpoint (UI SPA) returns HTML; must fail loudly, not silently.
+    respx.get(f"{ENDPOINT}/projects").mock(
+        return_value=httpx.Response(
+            200,
+            text="<!doctype html><html><head><title>UI</title></head></html>",
+            headers={"content-type": "text/html"},
+        )
+    )
+    with AllureClient(endpoint=ENDPOINT) as client:
+        with pytest.raises(AllureAPIError) as exc:
+            client.request_json("GET", "/projects")
+    assert "ALLURE_ENDPOINT" in exc.value.message
+    assert "text/html" in exc.value.message
+
+
+def test_encode_file_roundtrip():
+    raw = b'{"name": "test"}'
+    encoded = AllureClient.encode_file(raw)
+    assert base64.b64decode(encoded) == raw

--- a/allure-docker-mcp/tests/test_server.py
+++ b/allure-docker-mcp/tests/test_server.py
@@ -1,0 +1,228 @@
+"""Tests for the MCP tools, mocking the Allure REST API with respx."""
+
+import base64
+import json
+
+import httpx
+import pytest
+import respx
+
+from allure_docker_mcp import server
+from allure_docker_mcp.client import AllureClient
+
+ENDPOINT = "http://allure.test:5050"
+
+
+def call(tool, *args, **kwargs):
+    """Invoke a tool's synchronous core, bypassing the thread-offload wrapper.
+
+    The ``@server._tool`` decorator wraps each tool in an async function that
+    runs the body via ``anyio.to_thread``; ``functools.wraps`` exposes the
+    original sync function as ``__wrapped__`` so unit tests can drive the logic
+    directly without an event loop.
+    """
+    return tool.__wrapped__(*args, **kwargs)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Point the server's module-global client at the mocked endpoint."""
+    c = AllureClient(endpoint=ENDPOINT)
+    monkeypatch.setattr(server, "_client", c)
+    yield c
+    c.close()
+
+
+@respx.mock
+def test_get_version(client):
+    respx.get(f"{ENDPOINT}/version").mock(
+        return_value=httpx.Response(200, json={"data": {"version": "2.27.0"}})
+    )
+    assert call(server.get_version)["data"]["version"] == "2.27.0"
+
+
+@respx.mock
+def test_create_project_posts_id(client):
+    route = respx.post(f"{ENDPOINT}/projects").mock(
+        return_value=httpx.Response(201, json={"data": {"id": "demo"}})
+    )
+    result = call(server.create_project, "demo")
+    assert result["data"]["id"] == "demo"
+    assert json.loads(route.calls.last.request.read()) == {"id": "demo"}
+
+
+@respx.mock
+def test_delete_project_uses_path(client):
+    route = respx.delete(f"{ENDPOINT}/projects/demo").mock(
+        return_value=httpx.Response(200, json={"meta_data": {"message": "removed"}})
+    )
+    call(server.delete_project, "demo")
+    assert route.called
+
+
+@respx.mock
+def test_get_latest_report_returns_redirect_url(client):
+    # The service answers /latest-report with a 302 to the report index.html.
+    respx.get(f"{ENDPOINT}/latest-report").mock(
+        return_value=httpx.Response(
+            302,
+            headers={
+                "location": "/allure-docker-service/projects/demo/reports/latest/index.html"
+            },
+        )
+    )
+    result = call(server.get_latest_report, "demo")
+    assert result["report_url"] == (
+        f"{ENDPOINT}/allure-docker-service/projects/demo/reports/latest/index.html"
+    )
+
+
+@respx.mock
+def test_search_projects_passes_query(client):
+    route = respx.get(f"{ENDPOINT}/projects/search").mock(
+        return_value=httpx.Response(200, json={"data": {"projects": {}}})
+    )
+    call(server.search_projects, "dem")
+    assert route.calls.last.request.url.params["id"] == "dem"
+
+
+@respx.mock
+def test_generate_report_omits_none_params(client):
+    route = respx.get(f"{ENDPOINT}/generate-report").mock(
+        return_value=httpx.Response(200, json={"data": {}})
+    )
+    call(server.generate_report, project_id="demo", execution_name="ci")
+    params = route.calls.last.request.url.params
+    assert params["project_id"] == "demo"
+    assert params["execution_name"] == "ci"
+    assert "execution_from" not in params  # None values are dropped
+
+
+@respx.mock
+def test_send_results_wraps_payload(client):
+    route = respx.post(f"{ENDPOINT}/send-results").mock(
+        return_value=httpx.Response(200, json={"meta_data": {"message": "ok"}})
+    )
+    results = [{"file_name": "a.json", "content_base64": "e30="}]
+    call(server.send_results, results, project_id="demo", force_project_creation=True)
+    req = route.calls.last.request
+    assert req.url.params["force_project_creation"] == "true"
+    assert req.url.params["project_id"] == "demo"
+    assert json.loads(req.read())["results"] == results
+
+
+@respx.mock
+def test_send_results_from_directory_encodes_files(client, tmp_path):
+    (tmp_path / "result-1.json").write_text('{"a": 1}')
+    (tmp_path / "result-2.json").write_bytes(b"\x00\x01\x02")
+    (tmp_path / "subdir").mkdir()  # ignored
+
+    captured = {}
+
+    def _capture(request):
+        captured["body"] = json.loads(request.read())
+        return httpx.Response(200, json={"meta_data": {"message": "ok"}})
+
+    respx.post(f"{ENDPOINT}/send-results").mock(side_effect=_capture)
+    call(server.send_results_from_directory, str(tmp_path), project_id="demo")
+
+    sent = {r["file_name"]: r["content_base64"] for r in captured["body"]["results"]}
+    assert set(sent) == {"result-1.json", "result-2.json"}
+    assert base64.b64decode(sent["result-1.json"]) == b'{"a": 1}'
+    assert base64.b64decode(sent["result-2.json"]) == b"\x00\x01\x02"
+
+
+@respx.mock
+def test_send_results_from_directory_skips_symlinks(client, tmp_path):
+    # A regular result file plus a symlink pointing at a file OUTSIDE the dir.
+    (tmp_path / "result.json").write_text("{}")
+    store = tmp_path / "store"
+    store.mkdir()
+    secret = store / "secret"  # nested dir is not iterated at the top level
+    secret.write_text("password")
+    link = tmp_path / "leak.json"
+    try:
+        link.symlink_to(secret)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    captured = {}
+
+    def _capture(request):
+        captured["body"] = json.loads(request.read())
+        return httpx.Response(200, json={"meta_data": {"message": "ok"}})
+
+    respx.post(f"{ENDPOINT}/send-results").mock(side_effect=_capture)
+    call(server.send_results_from_directory, str(tmp_path))
+
+    names = {r["file_name"] for r in captured["body"]["results"]}
+    assert names == {"result.json"}  # the symlink "leak.json" is excluded
+
+
+def test_send_results_from_directory_rejects_missing_dir(client):
+    with pytest.raises(ValueError, match="Not a directory"):
+        call(server.send_results_from_directory, "/no/such/dir")
+
+
+@respx.mock
+def test_export_report_saves_zip(client, tmp_path, monkeypatch):
+    monkeypatch.setenv("ALLURE_OUTPUT_DIR", str(tmp_path))
+    respx.get(f"{ENDPOINT}/report/export").mock(
+        return_value=httpx.Response(
+            200, content=b"PK\x03\x04zip", headers={"content-type": "application/zip"}
+        )
+    )
+    result = call(server.export_report, "report.zip", project_id="demo")
+    payload = b"PK\x03\x04zip"
+    assert (tmp_path / "report.zip").read_bytes() == payload
+    assert result["bytes"] == len(payload)
+    assert result["content_type"] == "application/zip"
+
+
+def test_export_report_rejects_path_escape(client, tmp_path, monkeypatch):
+    # No respx route: confinement must fail before any HTTP request is made.
+    monkeypatch.setenv("ALLURE_OUTPUT_DIR", str(tmp_path))
+    with pytest.raises(ValueError, match="escapes"):
+        call(server.export_report, "../escape.zip")
+    with pytest.raises(ValueError, match="escapes"):
+        call(server.export_report, "/etc/cron.d/evil")
+
+
+def test_export_report_allows_nested_path_in_root(client, tmp_path, monkeypatch):
+    monkeypatch.setenv("ALLURE_OUTPUT_DIR", str(tmp_path))
+    with respx.mock:
+        respx.get(f"{ENDPOINT}/report/export").mock(
+            return_value=httpx.Response(200, content=b"zip", headers={"content-type": "application/zip"})
+        )
+        result = call(server.export_report, "sub/dir/report.zip", project_id="demo")
+    assert (tmp_path / "sub" / "dir" / "report.zip").read_bytes() == b"zip"
+    assert result["saved_to"].endswith("report.zip")
+
+
+@respx.mock
+def test_render_emailable_report_returns_html(client):
+    respx.get(f"{ENDPOINT}/emailable-report/render").mock(
+        return_value=httpx.Response(200, text="<html>report</html>")
+    )
+    assert call(server.render_emailable_report, "demo") == "<html>report</html>"
+
+
+def test_configure_transport_applies_fastmcp_host_port(monkeypatch):
+    # Guards the regression where FASTMCP_* env vars were silently ignored and
+    # the HTTP server never bound to the requested host/port.
+    orig = (server.mcp.settings.host, server.mcp.settings.port)
+    monkeypatch.setenv("ALLURE_MCP_TRANSPORT", "streamable-http")
+    monkeypatch.setenv("FASTMCP_HOST", "0.0.0.0")
+    monkeypatch.setenv("FASTMCP_PORT", "8123")
+    try:
+        transport = server._configure_transport()
+        assert transport == "streamable-http"
+        assert server.mcp.settings.host == "0.0.0.0"
+        assert server.mcp.settings.port == 8123
+    finally:
+        server.mcp.settings.host, server.mcp.settings.port = orig
+
+
+def test_configure_transport_defaults_to_stdio(monkeypatch):
+    monkeypatch.delenv("ALLURE_MCP_TRANSPORT", raising=False)
+    assert server._configure_transport() == "stdio"


### PR DESCRIPTION
## Summary

Adds a **Model Context Protocol (MCP)** server (`allure-docker-mcp/`) that exposes a running `allure-docker-service` instance as tools an LLM agent can call — from Claude Desktop, Claude Code, or any MCP host. It lets an assistant manage projects, send results, and generate/export Allure reports through natural language, e.g.:

> "Create a project `regression-suite`, send the results from `./allure-results`, generate a report, and give me the URL."

The server is a **client** of the existing REST API — it does not modify the service.

Closes #291

## What's included

- **16 tools**, one per REST endpoint: `get_version`, `get_config`, `list_projects`, `get_project`, `search_projects`, `create_project`, `delete_project`, `send_results`, `send_results_from_directory`, `generate_report`, `get_latest_report`, `clean_results`, `clean_history`, `export_report`, `export_emailable_report`, `render_emailable_report`.
- **Security mode** support: JWT-cookie login + `X-CSRF-TOKEN` on mutating requests, with a single 401 re-auth retry.
- **stdio**, **streamable-http**, and **sse** transports; `Dockerfile`; `pyproject.toml`; `.env.example`.
- Unit tests (respx-mocked) and a README with client-config examples.

## Design / hardening notes

A few items came out of review + testing against a real instance:

- **Export confinement** — `export_*` tools write only inside `ALLURE_OUTPUT_DIR` and reject path escapes (no arbitrary-file overwrite from an agent-chosen path).
- **Symlinks skipped** in `send_results_from_directory` so it can't be pointed at a symlink resolving outside the directory.
- **Non-blocking tools** — tool bodies run off the event loop (`anyio.to_thread`) so the HTTP transports stay responsive; client auth is lock-guarded for concurrent callers.
- **HTTP bind fix** — `main()` applies `FASTMCP_HOST`/`FASTMCP_PORT` to the live settings (FastMCP otherwise ignores them, so `streamable-http` never bound the requested port). Verified the server now binds the requested host/port.
- **Clear endpoint errors** — if `ALLURE_ENDPOINT` points at the web UI instead of the API base, tools return an actionable error instead of opaque HTML.

## Testing

- `pytest` — 24 tests pass (client auth/CSRF/401-retry, endpoint mapping, path confinement, symlink skip, transport config).
- Live integration against `frankescobar/allure-docker-service` (v2.38.1), driven through the real MCP tool dispatch:
  - **non-secure**: full lifecycle create → send → generate → latest-report → export → delete.
  - **security mode** (`SECURITY_ENABLED=1`): same lifecycle, exercising login + CSRF.
  - export confinement rejecting an out-of-root path; `streamable-http` real bind test on a non-default port.

## Notes for maintainers

- Scoped entirely to a new `allure-docker-mcp/` directory; no changes to `allure-docker-api` or the image.
- Requires Python 3.10+. Apache-2.0, same as the project.
- The HTTP transports are unauthenticated (documented in the package README) — intended to run locally or behind an authenticating proxy; `stdio` has no network surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
